### PR TITLE
feat: configurable ingest retry cap

### DIFF
--- a/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
@@ -31,7 +31,7 @@ public final class Config {
     private static final String PYROSCOPE_PUSH_QUEUE_CAPACITY_CONFIG = "PYROSCOPE_PUSH_QUEUE_CAPACITY";
     private static final String PYROSCOPE_LABELS = "PYROSCOPE_LABELS";
 
-    private static final String PYROSCOPE_INGEST_MAX_RETRIES = "PYROSCOPE_INGEST_MAX_RETRIES";
+    private static final String PYROSCOPE_INGEST_MAX_TRIES = "PYROSCOPE_INGEST_MAX_TRIES";
 
     public static final String DEFAULT_SPY_NAME = "javaspy";
     private static final Duration DEFAULT_PROFILING_INTERVAL = Duration.ofMillis(10);
@@ -63,7 +63,7 @@ public final class Config {
     public final Format format;
     public final int pushQueueCapacity;
     public final Map<String, String> labels;
-    public final int ingestMaxRetries;
+    public final int ingestMaxTries;
 
     Config(final String applicationName,
            final Duration profilingInterval,
@@ -87,7 +87,7 @@ public final class Config {
         this.logLevel = logLevel;
         this.serverAddress = serverAddress;
         this.authToken = authToken;
-        this.ingestMaxRetries = ingestMaxRetries;
+        this.ingestMaxTries = ingestMaxRetries;
         this.timeseries = timeseriesName(AppName.parse(applicationName), profilingEvent, format);
         this.timeseriesName = timeseries.toString();
         this.format = format;
@@ -322,7 +322,7 @@ public final class Config {
     }
 
     private static int ingestMaxRetries(ConfigurationProvider configurationProvider) {
-        final String strIngestMaxRetries = configurationProvider.get(PYROSCOPE_INGEST_MAX_RETRIES);
+        final String strIngestMaxRetries = configurationProvider.get(PYROSCOPE_INGEST_MAX_TRIES);
         if (strIngestMaxRetries == null || strIngestMaxRetries.isEmpty()) {
             return DEFAULT_INGEST_MAX_RETRIES;
         }

--- a/agent/src/main/java/io/pyroscope/javaagent/impl/PyroscopeExporter.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/impl/PyroscopeExporter.java
@@ -48,10 +48,11 @@ public class PyroscopeExporter implements Exporter {
         boolean success = false;
         int tries = 0;
         while (!success) {
+            tries++;
             final RequestBody requestBody;
             if (config.format == Format.JFR) {
                 byte[] labels = snapshot.labels.toByteArray();
-                logger.log(Logger.Level.DEBUG, "Upload attempt. JFR: %s, labels: %s", snapshot.data.length, labels.length);
+                logger.log(Logger.Level.DEBUG, "Upload attempt %d. JFR: %s, labels: %s", tries, snapshot.data.length, labels.length);
                 MultipartBody.Builder bodyBuilder = new MultipartBody.Builder()
                     .setType(MultipartBody.FORM);
                 bodyBuilder.addFormDataPart(
@@ -68,7 +69,7 @@ public class PyroscopeExporter implements Exporter {
                 }
                 requestBody = bodyBuilder.build();
             } else {
-                logger.log(Logger.Level.DEBUG, "Upload attempt. collapsed: %s", snapshot.data.length);
+                logger.log(Logger.Level.DEBUG, "Upload attempt %d. collapsed: %s", tries, snapshot.data.length);
                 requestBody = RequestBody.create(snapshot.data);
             }
             Request.Builder request = new Request.Builder()
@@ -94,8 +95,7 @@ public class PyroscopeExporter implements Exporter {
             } catch (final IOException e) {
                 logger.log(Logger.Level.ERROR, "Error uploading snapshot: %s", e.getMessage());
             }
-            tries++;
-            if (config.ingestMaxRetries > 0 && tries > config.ingestMaxRetries) {
+            if (config.ingestMaxTries >= 0 && tries >= config.ingestMaxTries) {
                 logger.log(Logger.Level.ERROR, "Gave up uploading profiling snapshot after %d tries", tries);
                 break;
             }


### PR DESCRIPTION
https://github.com/pyroscope-io/pyroscope/issues/1793

Add a new configuration option `PYROSCOPE_INGEST_MAX_TRIES` (Default is 8)
Example :
`PYROSCOPE_INGEST_MAX_TRIES=2` - try uploading a profile at most 2 times and then discard if not succeeded
`PYROSCOPE_INGEST_MAX_TRIES=-1` - try uploading a profile infinitely until succeeded
