### PR TITLE
Exposed the AsyncProfiler stop method

### DIFF
--- a/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
@@ -13,6 +13,8 @@ public class PyroscopeAgent {
     // this is used to store the options passed to the agent
     private static final AtomicReference<Options> startOptions = new AtomicReference<>(null);
 
+    private static final String stopLock = "";
+
     public static void premain(final String agentArgs,
                                final Instrumentation inst) {
         final Config config;
@@ -57,25 +59,27 @@ public class PyroscopeAgent {
      * stop is used to stop profiling
      */
     public static void stop() {
-        if (startOptions.get() == null) {
-            return;
-        }
-        ProfilingScheduler scheduler = startOptions.get().scheduler;
-        Logger logger = startOptions.get().logger;
-        Profiler profiler = startOptions.get().profiler;
+        synchronized (stopLock) {
+            if (startOptions.get() == null) {
+                return;
+            }
+            ProfilingScheduler scheduler = startOptions.get().scheduler;
+            Logger logger = startOptions.get().logger;
+            Profiler profiler = startOptions.get().profiler;
 
-        if (logger == null) {
-            return;
-        }
-        if (scheduler == null || profiler == null) {
-            logger.log(Logger.Level.ERROR, "Failed to stop profiling - already stopped");
-            return;
-        }
+            if (logger == null) {
+                return;
+            }
+            if (scheduler == null || profiler == null) {
+                logger.log(Logger.Level.ERROR, "Failed to stop profiling - already stopped");
+                return;
+            }
 
-        logger.log(Logger.Level.DEBUG, "Config: %s", startOptions.get().config);
-        scheduler.stop(profiler);
-        startOptions.set(null);
-        logger.log(Logger.Level.INFO, "Profiling stopped");
+            logger.log(Logger.Level.DEBUG, "Config: %s", startOptions.get().config);
+            scheduler.stop(profiler);
+            startOptions.set(null);
+            logger.log(Logger.Level.INFO, "Profiling stopped");
+        }
     }
 
     /**

--- a/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
@@ -57,7 +57,7 @@ public class PyroscopeAgent {
         logger.log(Logger.Level.DEBUG, "Config: %s", options.config);
         try {
             options.scheduler.stop(options.profiler);
-            logger.log(Logger.Level.INFO, "Profiling started");
+            logger.log(Logger.Level.INFO, "Profiling stopped");
         } catch (final Throwable e) {
             logger.log(Logger.Level.ERROR, "Error starting profiler %s", e);
         }

--- a/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
@@ -15,6 +15,8 @@ public class PyroscopeAgent {
 
     private static final String stopLock = "";
 
+    private static final String startLock = "";
+
     public static void premain(final String agentArgs,
                                final Instrumentation inst) {
         final Config config;
@@ -37,21 +39,23 @@ public class PyroscopeAgent {
     }
 
     public static void start(Options options) {
-        Logger logger = options.logger;
-        if (!startOptions.compareAndSet(null, options)) {
-            logger.log(Logger.Level.ERROR, "Failed to start profiling - already started");
-            return;
-        }
-        if (!options.config.agentEnabled) {
-            logger.log(Logger.Level.INFO, "Pyroscope agent start disabled by configuration");
-            return;
-        }
-        logger.log(Logger.Level.DEBUG, "Config: %s", options.config);
-        try {
-            options.scheduler.start(options.profiler);
-            logger.log(Logger.Level.INFO, "Profiling started");
-        } catch (final Throwable e) {
-            logger.log(Logger.Level.ERROR, "Error starting profiler %s", e);
+        synchronized (startLock) {
+            Logger logger = options.logger;
+            if (!startOptions.compareAndSet(null, options)) {
+                logger.log(Logger.Level.ERROR, "Failed to start profiling - already started");
+                return;
+            }
+            if (!options.config.agentEnabled) {
+                logger.log(Logger.Level.INFO, "Pyroscope agent start disabled by configuration");
+                return;
+            }
+            logger.log(Logger.Level.DEBUG, "Config: %s", options.config);
+            try {
+                options.scheduler.start(options.profiler);
+                logger.log(Logger.Level.INFO, "Profiling started");
+            } catch (final Throwable e) {
+                logger.log(Logger.Level.ERROR, "Error starting profiler %s", e);
+            }
         }
     }
 

--- a/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
@@ -49,6 +49,21 @@ public class PyroscopeAgent {
     }
 
     /**
+     * stop is used to stop profiling
+     * @param options
+     */
+    public static void stop(Options options) {
+        Logger logger = options.logger;
+        logger.log(Logger.Level.DEBUG, "Config: %s", options.config);
+        try {
+            options.scheduler.stop(options.profiler);
+            logger.log(Logger.Level.INFO, "Profiling started");
+        } catch (final Throwable e) {
+            logger.log(Logger.Level.ERROR, "Error starting profiler %s", e);
+        }
+    }
+
+    /**
      * Options allow to swap pyroscope components:
      * - io.pyroscope.javaagent.api.ProfilingScheduler
      * - org.apache.logging.log4j.Logger

--- a/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
@@ -61,6 +61,10 @@ public class PyroscopeAgent {
     public static void stop() {
         Logger logger = startOptions.get().logger;
         logger.log(Logger.Level.DEBUG, "Config: %s", startOptions.get().config);
+        if( startOptions.get() == null) {
+            logger.log(Logger.Level.ERROR, "Failed to start profiling - already started");
+            return;
+        }
         try {
             startOptions.get().scheduler.stop(startOptions.get().profiler);
             startOptions.set(null);

--- a/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
@@ -59,7 +59,7 @@ public class PyroscopeAgent {
             options.scheduler.stop(options.profiler);
             logger.log(Logger.Level.INFO, "Profiling stopped");
         } catch (final Throwable e) {
-            logger.log(Logger.Level.ERROR, "Error starting profiler %s", e);
+            logger.log(Logger.Level.ERROR, "Error stopping profiler %s", e);
         }
     }
 

--- a/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
@@ -37,9 +37,9 @@ public class PyroscopeAgent {
 
     public static void start(Options options) {
         Logger logger = options.logger;
-       if( !startOptions.compareAndSet(null, options)) {
-        logger.log(Logger.Level.ERROR, "Failed to start profiling - already started");
-        return;
+        if( !startOptions.compareAndSet(null, options)) {
+            logger.log(Logger.Level.ERROR, "Failed to start profiling - already started");
+            return;
         }
         if (!options.config.agentEnabled) {
             logger.log(Logger.Level.INFO, "Pyroscope agent start disabled by configuration");
@@ -47,9 +47,8 @@ public class PyroscopeAgent {
         }
         logger.log(Logger.Level.DEBUG, "Config: %s", options.config);
         try {
-            startOptions.compareAndSet(null, options);
-            startOptions.get().scheduler.start(startOptions.get().profiler);
-            logger.log(Logger.Level.INFO, "Profiling started");
+           options.scheduler.start(options.profiler);
+           logger.log(Logger.Level.INFO, "Profiling started");
         } catch (final Throwable e) {
             logger.log(Logger.Level.ERROR, "Error starting profiler %s", e);
         }
@@ -59,19 +58,17 @@ public class PyroscopeAgent {
      * stop is used to stop profiling
      */
     public static void stop() {
-        Logger logger = startOptions.get().logger;
-        logger.log(Logger.Level.DEBUG, "Config: %s", startOptions.get().config);
-        if( startOptions.get() == null) {
-            logger.log(Logger.Level.ERROR, "Failed to start profiling - already started");
+
+        if(startOptions.get() == null) {
             return;
         }
-        try {
-            startOptions.get().scheduler.stop(startOptions.get().profiler);
-            startOptions.set(null);
-            logger.log(Logger.Level.INFO, "Profiling stopped");
-        } catch (final Throwable e) {
-            logger.log(Logger.Level.ERROR, "Error stopping profiler %s", e);
-        }
+
+        Logger logger = startOptions.get().logger;
+        logger.log(Logger.Level.DEBUG, "Config: %s", startOptions.get().config);
+        startOptions.get().scheduler.stop(startOptions.get().profiler);
+        startOptions.set(null);
+
+        logger.log(Logger.Level.INFO, "Profiling stopped");
     }
 
     /**

--- a/agent/src/main/java/io/pyroscope/javaagent/api/ProfilingScheduler.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/api/ProfilingScheduler.java
@@ -38,7 +38,7 @@ public interface ProfilingScheduler {
     void start(Profiler profiler);
 
 /**
- * stop is ised tp stp[ the profiler
+ * stop is used to stop the profiler
  * {@link Profiler#stop()}
  * {@link Profiler#dumpProfile(Instant, Instant)}
  * **/

--- a/agent/src/main/java/io/pyroscope/javaagent/api/ProfilingScheduler.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/api/ProfilingScheduler.java
@@ -36,4 +36,11 @@ public interface ProfilingScheduler {
      *
      **/
     void start(Profiler profiler);
+
+/**
+ * stop is ised tp stp[ the profiler
+ * {@link Profiler#stop()}
+ * {@link Profiler#dumpProfile(Instant, Instant)}
+ * **/
+    void stop(Profiler profiler);
 }

--- a/agent/src/main/java/io/pyroscope/javaagent/impl/ContinuousProfilingScheduler.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/impl/ContinuousProfilingScheduler.java
@@ -67,6 +67,15 @@ public class ContinuousProfilingScheduler implements ProfilingScheduler {
 
     }
 
+    /**
+     * Stops the profiling scheduler which stops the AsyncProfiler.
+     * @param profiler
+     */
+    @Override
+    public void stop(Profiler profiler) {
+        profiler.stop();
+    }
+
     private void stop() {
         if (job != null) {
             job.cancel(true);

--- a/agent/src/main/java/io/pyroscope/javaagent/impl/ContinuousProfilingScheduler.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/impl/ContinuousProfilingScheduler.java
@@ -74,6 +74,8 @@ public class ContinuousProfilingScheduler implements ProfilingScheduler {
     @Override
     public void stop(Profiler profiler) {
         profiler.stop();
+        // explicitly stop this.job
+        stop();
     }
 
     private void stop() {

--- a/agent/src/main/java/io/pyroscope/javaagent/impl/SamplingProfilingScheduler.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/impl/SamplingProfilingScheduler.java
@@ -77,6 +77,8 @@ public class SamplingProfilingScheduler implements ProfilingScheduler {
     @Override
     public void stop(Profiler profiler) {
         profiler.stop();
+        // explicitly stop this.job
+        stop();
     }
 
     private void dumpProfile(final Profiler profiler, final long samplingDurationMillis, final Duration uploadInterval) {

--- a/agent/src/main/java/io/pyroscope/javaagent/impl/SamplingProfilingScheduler.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/impl/SamplingProfilingScheduler.java
@@ -70,6 +70,15 @@ public class SamplingProfilingScheduler implements ProfilingScheduler {
         );
     }
 
+    /**
+     * Stops the profiling scheduler which stops the AsyncProfiler.
+     * @param profiler
+     */
+    @Override
+    public void stop(Profiler profiler) {
+        profiler.stop();
+    }
+
     private void dumpProfile(final Profiler profiler, final long samplingDurationMillis, final Duration uploadInterval) {
         Instant profilingStartTime = Instant.now();
         try {

--- a/agent/src/test/java/io/pyroscope/javaagent/PyroscopeAgentTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/PyroscopeAgentTest.java
@@ -50,6 +50,10 @@ public class PyroscopeAgentTest {
         PyroscopeAgent.start(optionsAgentEnabled);
 
         verify(profilingScheduler, times(1)).start(any());
+
+        PyroscopeAgent.stop();
+
+        verify(profilingScheduler, times(1)).stop(any());
     }
 
     @Test
@@ -58,4 +62,5 @@ public class PyroscopeAgentTest {
 
         verify(profilingScheduler, never()).start(any());
     }
+
 }

--- a/demo/src/main/java/App.java
+++ b/demo/src/main/java/App.java
@@ -33,10 +33,38 @@ public class App {
 
         appLogic();
 
-        Thread.sleep(2 * 60 * 1000);
-
-        // This is a naive implementation for the stop method
-        PyroscopeAgent.stop();
+        // Test this by creating a new thread, stop the agent,  sleeping for a second, and then restarting the agent.
+        Thread newThread = new Thread(new Runnable() {
+            public void run()
+            {
+                // Sleep for a second to make sure the agent has started
+                try {
+                    Thread.sleep(1000L);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                // Stop the agent after a second
+                PyroscopeAgent.stop();
+                try {
+                    Thread.sleep(1000L);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                // Start the agent back up again after a second
+                PyroscopeAgent.start(
+                    new PyroscopeAgent.Options.Builder(
+                        new Config.Builder()
+                            .setApplicationName("demo.app{qweqwe=asdasd}")
+                            .setServerAddress("http://localhost:4040")
+                            .setFormat(Format.JFR)
+                            .setLogLevel(Logger.Level.DEBUG)
+                            .setLabels(mapOf("user", "tolyan"))
+                            .build())
+//                .setExporter(new MyStdoutExporter())
+                        .build()
+                );
+            }});
+        newThread.start();
     }
 
     private static void appLogic() {

--- a/demo/src/main/java/App.java
+++ b/demo/src/main/java/App.java
@@ -31,22 +31,12 @@ public class App {
         );
         Pyroscope.setStaticLabels(mapOf("region", "us-east-1"));
 
-        Thread.sleep(5 * 60 * 1000);
+        appLogic();
+
+        Thread.sleep(2 * 60 * 1000);
 
         // This is a naive implementation for the stop method
-        PyroscopeAgent.stop(
-            new PyroscopeAgent.Options.Builder(
-                new Config.Builder()
-                    .setApplicationName("demo.app{qweqwe=asdasd}")
-                    .setServerAddress("http://localhost:4040")
-                    .setFormat(Format.JFR)
-                    .setLogLevel(Logger.Level.DEBUG)
-                    .setLabels(mapOf("user", "tolyan"))
-                    .build())
-                .build()
-        );
-
-        appLogic();
+        PyroscopeAgent.stop();
     }
 
     private static void appLogic() {

--- a/demo/src/main/java/App.java
+++ b/demo/src/main/java/App.java
@@ -16,7 +16,7 @@ import java.util.concurrent.Executors;
 public class App {
     public static final int N_THREADS = 8;
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
         PyroscopeAgent.start(
             new PyroscopeAgent.Options.Builder(
                 new Config.Builder()
@@ -30,6 +30,21 @@ public class App {
                 .build()
         );
         Pyroscope.setStaticLabels(mapOf("region", "us-east-1"));
+
+        Thread.sleep(5 * 60 * 1000);
+
+        // This is a naive implementation for the stop method
+        PyroscopeAgent.stop(
+            new PyroscopeAgent.Options.Builder(
+                new Config.Builder()
+                    .setApplicationName("demo.app{qweqwe=asdasd}")
+                    .setServerAddress("http://localhost:4040")
+                    .setFormat(Format.JFR)
+                    .setLogLevel(Logger.Level.DEBUG)
+                    .setLabels(mapOf("user", "tolyan"))
+                    .build())
+                .build()
+        );
 
         appLogic();
     }


### PR DESCRIPTION
As per https://github.com/grafana/pyroscope-java/issues/119 I had requested for the ability to do on-demand profiling. I have added a PR here to expose the stop method so we could stop profiling anytime in production after collecting samples for an amount of time. Please review and provide feedback. Apologies if standards are not followed 