### PR TITLE
fix: intermitent error on multithread

### DIFF
--- a/async-profiler-context/src/main/java/io/pyroscope/labels/ScopedContext.java
+++ b/async-profiler-context/src/main/java/io/pyroscope/labels/ScopedContext.java
@@ -5,11 +5,11 @@ import one.profiler.AsyncProfiler;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.WeakHashMap;
 import java.util.function.BiConsumer;
 
 public class ScopedContext implements AutoCloseable {
-    static final Map<Thread, Context> threadContext = new ConcurrentHashMap<>();
+    static final Map<Thread, Context> threadContext = Collections.synchronizedMap(new WeakHashMap<>());
 
     final Context previous;
     final Context current;

--- a/async-profiler-context/src/test/java/io/pyroscope/labels/LabelsTest.java
+++ b/async-profiler-context/src/test/java/io/pyroscope/labels/LabelsTest.java
@@ -68,7 +68,7 @@ public class LabelsTest {
                 assertEquals(1, v1.refCount.get());
             }
         }
-        assertEquals(0, ScopedContext.context.get().id);
+        assertEquals(0, ScopedContext.currentContext().id);
         assertEquals(0, ctxRef.refCount.get());
         assertEquals(1, k1.refCount.get());
         assertEquals(1, v1.refCount.get());
@@ -195,7 +195,7 @@ public class LabelsTest {
 
         }
         Pyroscope.LabelsWrapper.dump();
-        assertEquals(0, ScopedContext.context.get().id);
+        assertEquals(0, ScopedContext.currentContext().id);
         assertEquals(0, RefCounted.strings.valueToRef.size());
         assertEquals(0, RefCounted.contexts.valueToRef.size());
     }
@@ -226,7 +226,7 @@ public class LabelsTest {
         e.shutdown();
         e.awaitTermination(100, TimeUnit.SECONDS);
         Snapshot res = Pyroscope.LabelsWrapper.dump();
-        assertEquals(0, ScopedContext.context.get().id);
+        assertEquals(0, ScopedContext.currentContext().id);
         assertEquals(0, RefCounted.strings.valueToRef.size());
         assertEquals(0, RefCounted.contexts.valueToRef.size());
     }

--- a/async-profiler-context/src/test/java/io/pyroscope/labels/ScopedContextTest.java
+++ b/async-profiler-context/src/test/java/io/pyroscope/labels/ScopedContextTest.java
@@ -1,11 +1,15 @@
 package io.pyroscope.labels;
 
 import io.pyroscope.labels.io.pyroscope.PyroscopeAsyncProfiler;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class ScopedContextTest {
 
@@ -23,6 +27,30 @@ public class ScopedContextTest {
         ScopedContext context = new ScopedContext(new LabelsSet("k1", "v1"));
         executorService.submit(context::close).get();
         Pyroscope.LabelsWrapper.dump();
+        // Shouldn't error
         new ScopedContext(new LabelsSet("k1", "v1"));
+    }
+
+    @Test
+    void assertThreadNotLeaking() throws ExecutionException, InterruptedException {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        AtomicReference<WeakReference<Thread>> threadRef = new AtomicReference<>();
+        new Thread(() -> {
+            threadRef.set(new WeakReference<>(Thread.currentThread()));
+            ScopedContext context = new ScopedContext(new LabelsSet("k1", "v1"));
+            context.close();
+            future.complete(null);
+        }).start();
+        future.get();
+        Pyroscope.LabelsWrapper.dump();
+
+        // Force GC to clean the thread
+        System.gc();
+
+        Assertions.assertNull(threadRef.get().get(), "The thread should be garbage collected");
+
+        // In WeakHashMap we need to interact with the map so it can clean the stale references
+        ScopedContext.threadContext.forEach((thread, context) -> {});
+        Assertions.assertTrue(ScopedContext.threadContext.isEmpty(), "The map should be empty, as the thread doesn't exists anymore");
     }
 }

--- a/async-profiler-context/src/test/java/io/pyroscope/labels/ScopedContextTest.java
+++ b/async-profiler-context/src/test/java/io/pyroscope/labels/ScopedContextTest.java
@@ -1,0 +1,28 @@
+package io.pyroscope.labels;
+
+import io.pyroscope.labels.io.pyroscope.PyroscopeAsyncProfiler;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class ScopedContextTest {
+
+    static {
+        PyroscopeAsyncProfiler.getAsyncProfiler();
+    }
+
+
+    /**
+     * This test demonstrates the issue reported <a href="https://github.com/grafana/pyroscope-java/issues/70">here</a>
+     */
+    @Test
+    void closeContextOnOtherThread() throws ExecutionException, InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        ScopedContext context = new ScopedContext(new LabelsSet("k1", "v1"));
+        executorService.submit(context::close).get();
+        Pyroscope.LabelsWrapper.dump();
+        new ScopedContext(new LabelsSet("k1", "v1"));
+    }
+}


### PR DESCRIPTION
I changed the ScopedContext class to avoid error on closing the scoped context on a diferent thread than it was created.
I had this error on my project when using aws sdk for SQS but I assume it will throw this error for any aws service.

This fix the issue mentioned in #70 

I have also created a test that simulates the error, if it doesn't make sense to keep the test, let me know and I will remove it.