### PR TITLE
Bump async profiler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        java: ['11', '17', '21']
+        java: ['8', '11', '17', '21']
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: 'zulu'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
         os: [ubuntu, macos]
         java: ['8', '11', '17']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        java: ['8', '11', '17']
+        java: ['11', '17', '21']
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Test with Gradle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        java: ['11', '17', '21']
+        java: ['8', '11', '17', '21']
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: 'zulu'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Test with Gradle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        java: ['8', '11', '17', '21']
+        java: ['11', '17', '21']
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK

--- a/alpine-test.Dockerfile
+++ b/alpine-test.Dockerfile
@@ -1,22 +1,34 @@
 ARG IMAGE_VERSION
-FROM alpine:${IMAGE_VERSION}
-ARG IMAGE_VERSION
 ARG JAVA_VERSION
-RUN apk add openjdk${JAVA_VERSION}
+
+FROM alpine:3.20.3 AS builder
+RUN apk add openjdk8
+
 WORKDIR /app
-ADD gradlew build.gradle settings.gradle /app/
+ADD gradlew build.gradle settings.gradle gradle.properties /app/
 ADD gradle gradle
 RUN ./gradlew --no-daemon --version
 ADD agent agent
 ADD async-profiler-context async-profiler-context
 ADD demo/build.gradle demo/
 
+# for testing locally produced artifacts
+#COPY async-profiler-3.0.0.1-linux-x64.tar.gz .
+#COPY async-profiler-3.0.0.1-linux-arm64.tar.gz .
+#COPY async-profiler-3.0.0.1-macos.zip .
+
 RUN ./gradlew --no-daemon shadowJar
 
+FROM alpine:${IMAGE_VERSION} AS runner
+ARG IMAGE_VERSION
+ARG JAVA_VERSION
+RUN apk add openjdk${JAVA_VERSION}
+
+WORKDIR /app
 ADD demo demo
+COPY --from=builder /app/agent/build/libs/pyroscope.jar /app/agent/build/libs/pyroscope.jar
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/default-jvm/jre/bin
-
 
 RUN javac demo/src/main/java/Fib.java
 
@@ -24,4 +36,5 @@ ENV PYROSCOPE_LOG_LEVEL=debug
 ENV PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
 ENV PYROSCOPE_APPLICATION_NAME=alpine-${IMAGE_VERSION}-${JAVA_VERSION}
 ENV PYROSCOPE_UPLOAD_INTERVAL=15s
+
 CMD ["java", "-javaagent:/app/agent/build/libs/pyroscope.jar", "-cp", "demo/src/main/java/", "Fib"]

--- a/async-profiler-context/build.gradle
+++ b/async-profiler-context/build.gradle
@@ -21,7 +21,7 @@ repositories {
     mavenCentral()
 }
 
-def asyncProfilerVersion = "3.0.0.0"
+def asyncProfilerVersion = project.properties['async_profiler_version']
 def pyroscopeVersion = project.properties['pyroscope_version']
 dependencies {
     api files("$buildDir/async-profiler/async-profiler.jar")
@@ -64,18 +64,18 @@ shadowJar {
     archiveClassifier.set('')
 }
 
-task relocateShadowJar(type: ConfigureShadowRelocation) {
+tasks.register('relocateShadowJar', ConfigureShadowRelocation) {
     target = tasks.shadowJar
     prefix = "io.pyroscope"
 }
 tasks.shadowJar.dependsOn tasks.relocateShadowJar
 
-task asyncProfilerLib {
+tasks.register('asyncProfilerLib') {
+    def useLocalArtifacts = project.findProperty('useLocalAsyncProfilerArtifacts') == 'true'
+
     def suffixes = [
         ['linux-arm64', 'tar.gz'],
         ['linux-x64', 'tar.gz'],
-        ['linux-musl-x64', 'tar.gz'],
-        ['linux-musl-arm64', 'tar.gz'],
         ['macos', 'zip']
     ]
 
@@ -87,11 +87,18 @@ task asyncProfilerLib {
 
     doLast {
         suffixes.forEach { suffix, ext ->
-            def repo = "https://github.com/grafana/async-profiler"
-            download {
-                src "$repo/releases/download/v${asyncProfilerVersion}/async-profiler-${asyncProfilerVersion}-${suffix}.${ext}"
-                dest new File(asyncProfilerDir, "async-profiler-${asyncProfilerVersion}-${suffix}.${ext}")
-                overwrite true
+            if (!useLocalArtifacts) {
+                def repo = "https://github.com/grafana/async-profiler"
+                download {
+                    src "$repo/releases/download/v${asyncProfilerVersion}/async-profiler-${asyncProfilerVersion}-${suffix}.${ext}"
+                    dest new File(asyncProfilerDir, "async-profiler-${asyncProfilerVersion}-${suffix}.${ext}")
+                    overwrite true
+                }
+            } else {
+                copy {
+                    from file("../async-profiler-${asyncProfilerVersion}-${suffix}.${ext}")
+                    into asyncProfilerDir
+                }
             }
 
             // Extract the native library files.

--- a/docker-compose-itest.yaml
+++ b/docker-compose-itest.yaml
@@ -1,7 +1,8 @@
-version: '3.9'
 services:
   alpine-3.16-8:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -9,6 +10,8 @@ services:
         JAVA_VERSION: 8
   alpine-3.16-11:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -16,6 +19,8 @@ services:
         JAVA_VERSION: 11
   alpine-3.16-17:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -23,6 +28,8 @@ services:
         JAVA_VERSION: 17
   alpine-3.17-8:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -30,6 +37,8 @@ services:
         JAVA_VERSION: 8
   alpine-3.17-11:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -37,6 +46,8 @@ services:
         JAVA_VERSION: 11
   alpine-3.17-17:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -44,6 +55,8 @@ services:
         JAVA_VERSION: 17
   alpine-3.18-8:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -51,6 +64,8 @@ services:
         JAVA_VERSION: 8
   alpine-3.18-11:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -58,6 +73,8 @@ services:
         JAVA_VERSION: 11
   alpine-3.18-17:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -65,6 +82,8 @@ services:
         JAVA_VERSION: 17
   alpine-3.19-8:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -72,6 +91,8 @@ services:
         JAVA_VERSION: 8
   alpine-3.19-11:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -79,6 +100,8 @@ services:
         JAVA_VERSION: 11
   alpine-3.19-17:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: alpine-test.Dockerfile
       args:
@@ -87,6 +110,8 @@ services:
 
   ubuntu-18.04-8:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: ubuntu-test.Dockerfile
       args:
@@ -94,6 +119,8 @@ services:
         JAVA_VERSION: 8
   ubuntu-18.04-11:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: ubuntu-test.Dockerfile
       args:
@@ -101,6 +128,8 @@ services:
         JAVA_VERSION: 11
   ubuntu-18.04-17:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: ubuntu-test.Dockerfile
       args:
@@ -108,6 +137,8 @@ services:
         JAVA_VERSION: 17
   ubuntu-20.04-8:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: ubuntu-test.Dockerfile
       args:
@@ -115,6 +146,8 @@ services:
         JAVA_VERSION: 8
   ubuntu-20.04-11:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: ubuntu-test.Dockerfile
       args:
@@ -122,6 +155,8 @@ services:
         JAVA_VERSION: 11
   ubuntu-20.04-17:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: ubuntu-test.Dockerfile
       args:
@@ -129,6 +164,8 @@ services:
         JAVA_VERSION: 17
   ubuntu-20.04-21:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: ubuntu-test.Dockerfile
       args:
@@ -136,6 +173,8 @@ services:
         JAVA_VERSION: 21
   ubuntu-22.04-8:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: ubuntu-test.Dockerfile
       args:
@@ -143,6 +182,8 @@ services:
         JAVA_VERSION: 8
   ubuntu-22.04-11:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: ubuntu-test.Dockerfile
       args:
@@ -150,6 +191,8 @@ services:
         JAVA_VERSION: 11
   ubuntu-22.04-17:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: ubuntu-test.Dockerfile
       args:
@@ -157,6 +200,8 @@ services:
         JAVA_VERSION: 17
   ubuntu-22.04-21:
     build:
+      platforms:
+        - linux/amd64
       context: .
       dockerfile: ubuntu-test.Dockerfile
       args:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 pyroscope_version=0.14.1
+async_profiler_version=3.0.0.1
+useLocalAsyncProfilerArtifacts=false

--- a/ubuntu-test.Dockerfile
+++ b/ubuntu-test.Dockerfile
@@ -1,19 +1,32 @@
-ARG IMAGE_VERSION=18.04
-FROM ubuntu:${IMAGE_VERSION}
-ARG IMAGE_VERSION=18.04
-ARG JAVA_VERSION=11
-RUN apt-get update && apt-get install -y openjdk-${JAVA_VERSION}-jdk-headless
+ARG IMAGE_VERSION
+ARG JAVA_VERSION
+
+FROM ubuntu:18.04 AS builder
+RUN apt-get update && apt-get install -y openjdk-8-jdk-headless
+
 WORKDIR /app
-ADD gradlew build.gradle settings.gradle /app/
+ADD gradlew build.gradle settings.gradle gradle.properties /app/
 ADD gradle gradle
 RUN ./gradlew --no-daemon --version
 ADD agent agent
 ADD async-profiler-context async-profiler-context
 ADD demo/build.gradle demo/
 
+# for testing locally produced artifacts
+#COPY async-profiler-3.0.0.1-linux-x64.tar.gz .
+#COPY async-profiler-3.0.0.1-linux-arm64.tar.gz .
+#COPY async-profiler-3.0.0.1-macos.zip .
+
 RUN ./gradlew --no-daemon shadowJar
 
+FROM ubuntu:${IMAGE_VERSION} AS runner
+ARG IMAGE_VERSION
+ARG JAVA_VERSION
+RUN apt-get update && apt-get install -y openjdk-${JAVA_VERSION}-jdk-headless
+
+WORKDIR /app
 ADD demo demo
+COPY --from=builder /app/agent/build/libs/pyroscope.jar /app/agent/build/libs/pyroscope.jar
 
 RUN javac demo/src/main/java/Fib.java
 


### PR DESCRIPTION
Part of https://github.com/grafana/pyroscope-java/issues/168.

Updates the underlying profiler to include the following changes in async-profiler: https://github.com/async-profiler/async-profiler/compare/4e441b4024a5873a5764a1e8b9f0bb25ad997fbf...6682ad6fb020b2d237566e9352f69ad0899e68f5.

Depends on https://github.com/grafana/async-profiler/pull/4 being merged and a new version of `grafana/async-profiler` being produced (3.0.0.1). ✅ 

Main changes here:
- Bump the version of `grafana/async-profiler`
- Simplify library deployment, async-profiler no longer produces musl-specific binaries
- Add a simple way to test locally produced async-profiler binaries 