### PR TITLE
Move the release pipeline to a GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+name: Release
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Java 8
         uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,15 +71,17 @@ jobs:
             NEXUS_GPG_PASSWORD=publishing:nexus_gpg_key_id
             NEXUS_GPG_SECRING_FILE_BASE64=publishing:nexus_gpg_secring_file
 
-      - name: Decode GPG Keyring
+      - name: Prepare GPG Keyring
+        id: prepare_gpg_keyring
         run: |
           mkdir -p ${{ github.workspace }}/gpg
           echo "$NEXUS_GPG_SECRING_FILE_BASE64" | base64 -d > ${{ github.workspace }}/gpg/secring.gpg
           chmod 600 ${{ github.workspace }}/gpg/secring.gpg
-          export NEXUS_GPG_SECRING_FILE=${{ github.workspace }}/gpg/secring.gpg
+          echo "keyring_path=${{ github.workspace }}/gpg/secring.gpg" >> $GITHUB_OUTPUT
 
       - name: Build and Publish
         run: |
+          export NEXUS_GPG_SECRING_FILE=${{ steps.prepare_gpg_keyring.outputs.keyring_path }}
           make publish
 
       - name: Commit and Push Changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
             NEXUS_USERNAME=publishing:nexus_username
             NEXUS_PASSWORD=publishing:nexus_password
             NEXUS_GPG_KEY_ID=publishing:nexus_gpg_key_id
-            NEXUS_GPG_PASSWORD=publishing:nexus_gpg_key_id
+            NEXUS_GPG_PASSWORD=publishing:nexus_gpg_password
             NEXUS_GPG_SECRING_FILE_BASE64=publishing:nexus_gpg_secring_file
 
       - name: Prepare GPG Keyring

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ on:
           - patch
           - minor
           - major
-  pull_request:
 
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,18 +37,26 @@ jobs:
         id: bump_version
         run: |
           current_version=$(grep 'pyroscope_version=' gradle.properties | cut -d'=' -f2)
+          echo "Current version: $current_version"
+          IFS='.' read -r major minor patch <<< "$current_version"
 
           case "${{ inputs.version_bump }}" in
-            "patch")
-              new_version=$(echo $current_version | awk -F. '{$NF = $NF + 1;} 1' OFS=.)
+            "major")
+              major=$((major + 1))
+              minor=0
+              patch=0
               ;;
             "minor")
-              new_version=$(echo $current_version | awk -F. '{$(NF-1) = $(NF-1) + 1; $NF = 0;} 1' OFS=.)
+              minor=$((minor + 1))
+              patch=0
               ;;
-            "major")
-              new_version=$(echo $current_version | awk -F. '{$(1) = $(1) + 1; $(NF-1) = 0; $NF = 0;} 1' OFS=.)
+            "patch")
+              patch=$((patch + 1))
               ;;
           esac
+
+          new_version="${major}.${minor}.${patch}"
+          echo "New version: $new_version"
 
           sed -i "s/pyroscope_version=.*/pyroscope_version=$new_version/" gradle.properties
           echo "version=$new_version" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version Bump Type'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Bump Version
+        id: bump_version
+        run: |
+          current_version=$(grep 'pyroscope_version=' gradle.properties | cut -d'=' -f2)
+
+          case "${{ inputs.version_bump }}" in
+            "patch")
+              new_version=$(echo $current_version | awk -F. '{$NF = $NF + 1;} 1' OFS=.)
+              ;;
+            "minor")
+              new_version=$(echo $current_version | awk -F. '{$(NF-1) = $(NF-1) + 1; $NF = 0;} 1' OFS=.)
+              ;;
+            "major")
+              new_version=$(echo $current_version | awk -F. '{$(1) = $(1) + 1; $(NF-1) = 0; $NF = 0;} 1' OFS=.)
+              ;;
+          esac
+
+          sed -i "s/pyroscope_version=.*/pyroscope_version=$new_version/" gradle.properties
+          echo "version=$new_version" >> $GITHUB_OUTPUT
+
+      - name: Get secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            NEXUS_USERNAME=publishing:nexus_username
+            NEXUS_PASSWORD=publishing:nexus_password
+            NEXUS_GPG_KEY_ID=publishing:nexus_gpg_key_id
+            NEXUS_GPG_PASSWORD=publishing:nexus_gpg_key_id
+            NEXUS_GPG_SECRING_FILE_BASE64=publishing:nexus_gpg_secring_file
+
+      - name: Decode GPG Keyring
+        run: |
+          mkdir -p ${{ github.workspace }}/gpg
+          echo "$NEXUS_GPG_SECRING_FILE_BASE64" | base64 -d > ${{ github.workspace }}/gpg/secring.gpg
+          chmod 600 ${{ github.workspace }}/gpg/secring.gpg
+          export NEXUS_GPG_SECRING_FILE=${{ github.workspace }}/gpg/secring.gpg
+
+      - name: Build and Publish
+        run: |
+          make publish
+
+      - name: Commit and Push Changes
+        run: |
+          git add gradle.properties
+          git commit -m "version ${{ steps.bump_version.outputs.version }}"
+          git tag "v${{ steps.bump_version.outputs.version }}"
+          git push --atomic origin "refs/heads/main" "refs/tags/v${{ steps.bump_version.outputs.version }}"
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.bump_version.outputs.version }}" \
+            agent/build/libs/pyroscope.jar \
+            --title "Release v${{ steps.bump_version.outputs.version }}" \
+            --notes "Automated release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
           - patch
           - minor
           - major
+  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,11 @@ jobs:
           make publish
 
       - name: Commit and Push Changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add gradle.properties
           git commit -m "version ${{ steps.bump_version.outputs.version }}"
           git tag "v${{ steps.bump_version.outputs.version }}"

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ build:
 .PHONY: publish
 publish:
 	@echo "./gradlew clean :agent:shadowJar publishToSonatype closeAndReleaseSonatypeStagingRepository"
-	@./gradlew clean :agent:shadowJar publishToSonatype closeAndReleaseSonatypeStagingRepository \
+	@./gradlew clean :agent:shadowJar publishToSonatype \
 		-PsonatypeUsername="$(NEXUS_USERNAME)" \
 		-PsonatypePassword="$(NEXUS_PASSWORD)" \
 		-Psigning.secretKeyRingFile="$(NEXUS_GPG_SECRING_FILE)" \
 		-Psigning.password="$(NEXUS_GPG_PASSWORD)" \
 		-Psigning.keyId="$(NEXUS_GPG_KEY_ID)"
-	@echo "Now you go https://s01.oss.sonatype.org, close the temporarly created staging repository and release it"
+	@echo "Now you go https://s01.oss.sonatype.org, close the temporarily created staging repository and release it"
 	@echo "https://central.sonatype.org/publish/release/#locate-and-examine-your-staging-repository"
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,12 @@ build:
 .PHONY: publish
 publish:
 	@echo "./gradlew clean :agent:shadowJar publishToSonatype closeAndReleaseSonatypeStagingRepository"
-	@./gradlew clean :agent:shadowJar publishToSonatype \
+	@./gradlew clean :agent:shadowJar publishToSonatype closeAndReleaseSonatypeStagingRepository \
 		-PsonatypeUsername="$(NEXUS_USERNAME)" \
 		-PsonatypePassword="$(NEXUS_PASSWORD)" \
 		-Psigning.secretKeyRingFile="$(NEXUS_GPG_SECRING_FILE)" \
 		-Psigning.password="$(NEXUS_GPG_PASSWORD)" \
 		-Psigning.keyId="$(NEXUS_GPG_KEY_ID)"
-	@echo "Now you go https://s01.oss.sonatype.org, close the temporarily created staging repository and release it"
 	@echo "https://central.sonatype.org/publish/release/#locate-and-examine-your-staging-repository"
 
 .PHONY: test


### PR DESCRIPTION
For reference, the current Jenkins job looks somewhat like this

```
set -e

GIT_COMMIT=$(git rev-parse $reference)

echo "releasing $GIT_COMMIT"

git config user.name <redacted>
git config user.email <redacted>

git checkout -b main

sed -i "s/pyroscope_version=.*/pyroscope_version=$version/" gradle.properties

# make build # publish only to github
make publish

git add gradle.properties
git commit -m "version $version"
git tag "v$version" 
git push --atomic origin "refs/heads/main"  "refs/tags/v$version" 

gh release create "v$version" --title '' --notes ''
gh release upload "v$version" agent/build/libs/pyroscope.jar
```