### PR TITLE
Prevent multiple async-profiler library deployments

### DIFF
--- a/async-profiler-context/src/main/java/io/pyroscope/labels/io/pyroscope/PyroscopeAsyncProfiler.java
+++ b/async-profiler-context/src/main/java/io/pyroscope/labels/io/pyroscope/PyroscopeAsyncProfiler.java
@@ -40,17 +40,10 @@ public class PyroscopeAsyncProfiler {
     private static String deployLibrary() throws IOException {
         final String fileName = libraryFileName();
         final String userName = System.getProperty("user.name");
-        final String tmpDir = System.getProperty("java.io.tmpdir");
-        final File targetDir = new File(tmpDir, userName + "-pyroscope/");
-        targetDir.mkdirs();
-
-        final Path target = targetDir.toPath().resolve(targetLibraryFileName(fileName)).toAbsolutePath();
-        if (Files.exists(target)) {
-            // library already deployed
-            return target.toString();
-        }
+        final Path targetDir = Files.createTempDirectory( userName + "-pyroscope");
 
         try (final InputStream is = loadResource(fileName)) {
+            final Path target = targetDir.resolve(targetLibraryFileName(fileName)).toAbsolutePath();
             Files.copy(is, target, StandardCopyOption.REPLACE_EXISTING);
             return target.toString();
         }

--- a/async-profiler-context/src/main/java/io/pyroscope/labels/io/pyroscope/PyroscopeAsyncProfiler.java
+++ b/async-profiler-context/src/main/java/io/pyroscope/labels/io/pyroscope/PyroscopeAsyncProfiler.java
@@ -44,8 +44,13 @@ public class PyroscopeAsyncProfiler {
         final File targetDir = new File(tmpDir, userName + "-pyroscope/");
         targetDir.mkdirs();
 
+        final Path target = targetDir.toPath().resolve(targetLibraryFileName(fileName)).toAbsolutePath();
+        if (Files.exists(target)) {
+            // library already deployed
+            return target.toString();
+        }
+
         try (final InputStream is = loadResource(fileName)) {
-            final Path target = targetDir.toPath().resolve(targetLibraryFileName(fileName)).toAbsolutePath();
             Files.copy(is, target, StandardCopyOption.REPLACE_EXISTING);
             return target.toString();
         }

--- a/async-profiler-context/src/test/java/io/pyroscope/ConcurrentUsageTest.java
+++ b/async-profiler-context/src/test/java/io/pyroscope/ConcurrentUsageTest.java
@@ -7,10 +7,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ConcurrentUseTest {
+public class ConcurrentUsageTest {
 
     @Test
-    public void testConcurrentUsage() throws IOException {
+    public void runConcurrently() throws IOException {
         int iterations = 10;
         List<Process> processes = new ArrayList<>();
         for (int i = 0; i < iterations; i++) {

--- a/async-profiler-context/src/test/java/io/pyroscope/ConcurrentUseTest.java
+++ b/async-profiler-context/src/test/java/io/pyroscope/ConcurrentUseTest.java
@@ -1,0 +1,36 @@
+package io.pyroscope;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConcurrentUseTest {
+
+    @Test
+    public void testConcurrentUsage() throws IOException {
+        int iterations = 10;
+        List<Process> processes = new ArrayList<>();
+        for (int i = 0; i < iterations; i++) {
+            Process process = new ProcessBuilder(
+                "java", "-cp", System.getProperty("java.class.path"), TestApplication.class.getName()
+            ).inheritIO().start();
+            processes.add(process);
+        }
+
+        processes.parallelStream().forEach(p -> {
+            int exitCode = 0;
+            try {
+                exitCode = p.waitFor();
+            } catch (InterruptedException e) {
+                Assertions.fail("could not get process status", e);
+            }
+            if (exitCode != 0) {
+                Assertions.fail("process failed with exit code: " + exitCode);
+            }
+        });
+    }
+}
+

--- a/async-profiler-context/src/test/java/io/pyroscope/TestApplication.java
+++ b/async-profiler-context/src/test/java/io/pyroscope/TestApplication.java
@@ -1,0 +1,26 @@
+package io.pyroscope;
+
+import io.pyroscope.labels.io.pyroscope.PyroscopeAsyncProfiler;
+import one.profiler.AsyncProfiler;
+import one.profiler.Counter;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestApplication {
+
+    public static void main(String[] args) {
+        AsyncProfiler asyncProfiler = PyroscopeAsyncProfiler.getAsyncProfiler();
+        asyncProfiler.start("cpu", TimeUnit.SECONDS.toNanos(1));
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            System.exit(1);
+        }
+        asyncProfiler.stop();
+
+        System.out.println(
+            asyncProfiler + "-" +
+                asyncProfiler.dumpCollapsed(Counter.SAMPLES).split(";").length
+        );
+    }
+}


### PR DESCRIPTION
If we try to load the `async-profiler` library from multiple processes at the same time, loading can fail because we are trying to deploy the app multiple times. 

One case where this can happen is when the SDK is used in concurrently executed unit tests.

```
Caused by: java.nio.file.FileAlreadyExistsException: /var/folders/rl/p7hzvh8943v6xf55qksjjc240000gn/T/redacted-pyroscope/libasyncProfiler-redacted-6bf68b96dcb6e8ec20caa84e1e69e6659f17f5.so
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:94)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:262)
	at java.base/java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:482)
	at java.base/java.nio.file.Files.newOutputStream(Files.java:228)
	at java.base/java.nio.file.Files.copy(Files.java:3164)
	at io.pyroscope.labels.io.pyroscope.PyroscopeAsyncProfiler.deployLibrary(PyroscopeAsyncProfiler.java:54)
	at io.pyroscope.labels.io.pyroscope.PyroscopeAsyncProfiler.<clinit>(PyroscopeAsyncProfiler.java:25)
```

An alternative approach is to use `Files.createTempDirectory` which will result in separate deployments for each process, though in the case of unit testing this can be wasteful.