### PR TITLE
Add `ProfilerApi` to improve interoperability with the open telemetry extension

### DIFF
--- a/agent/src/main/java/io/pyroscope/javaagent/ProfilerSdk.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/ProfilerSdk.java
@@ -1,0 +1,28 @@
+package io.pyroscope.javaagent;
+
+import io.pyroscope.javaagent.api.ProfilerScopedContext;
+import io.pyroscope.javaagent.api.ProfilerApi;
+import io.pyroscope.javaagent.config.Config;
+import io.pyroscope.javaagent.impl.ProfilerScopedContextWrapper;
+import io.pyroscope.labels.LabelsSet;
+import io.pyroscope.labels.ScopedContext;
+
+import java.util.Map;
+
+public class ProfilerSdk implements ProfilerApi {
+
+    @Override
+    public void startProfiling() {
+        PyroscopeAgent.start(Config.build());
+    }
+
+    @Override
+    public boolean isProfilingStarted() {
+        return PyroscopeAgent.isStarted();
+    }
+
+    @Override
+    public ProfilerScopedContext createScopedContext(Map<String, String> labels) {
+        return new ProfilerScopedContextWrapper(new ScopedContext(new LabelsSet(labels)));
+    }
+}

--- a/agent/src/main/java/io/pyroscope/javaagent/api/ProfilerApi.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/api/ProfilerApi.java
@@ -1,0 +1,9 @@
+package io.pyroscope.javaagent.api;
+
+import java.util.Map;
+
+public interface ProfilerApi {
+    void startProfiling();
+    boolean isProfilingStarted();
+    ProfilerScopedContext createScopedContext(Map<String, String> labels);
+}

--- a/agent/src/main/java/io/pyroscope/javaagent/api/ProfilerScopedContext.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/api/ProfilerScopedContext.java
@@ -1,0 +1,8 @@
+package io.pyroscope.javaagent.api;
+
+import java.util.function.BiConsumer;
+
+public interface ProfilerScopedContext {
+    void forEachLabel(BiConsumer<String, String> consumer);
+    void close();
+}

--- a/agent/src/main/java/io/pyroscope/javaagent/impl/ProfilerScopedContextWrapper.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/impl/ProfilerScopedContextWrapper.java
@@ -1,0 +1,24 @@
+package io.pyroscope.javaagent.impl;
+
+import io.pyroscope.javaagent.api.ProfilerScopedContext;
+import io.pyroscope.labels.ScopedContext;
+
+import java.util.function.BiConsumer;
+
+public class ProfilerScopedContextWrapper implements ProfilerScopedContext {
+    private final ScopedContext ctx;
+
+    public ProfilerScopedContextWrapper(ScopedContext ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void forEachLabel(BiConsumer<String, String> consumer) {
+        ctx.forEachLabel(consumer);
+    }
+
+    @Override
+    public void close() {
+        ctx.close();
+    }
+}

--- a/async-profiler-context/src/main/java/io/pyroscope/labels/ScopedContext.java
+++ b/async-profiler-context/src/main/java/io/pyroscope/labels/ScopedContext.java
@@ -61,7 +61,6 @@ public class ScopedContext implements AutoCloseable {
         context.set(current);
     }
 
-
     @Override
     public void close() {
         if (closed) {
@@ -73,9 +72,9 @@ public class ScopedContext implements AutoCloseable {
         AsyncProfiler.getInstance().setContextId(previous.id);
     }
 
-    public void forEach(BiConsumer<String, String> consumer) {
+    public void forEachLabel(BiConsumer<String, String> labelConsumer) {
         for (Map.Entry<Ref<String>, Ref<String>> it : current.labels.entrySet()) {
-            consumer.accept(it.getKey().val, it.getValue().val);
+            labelConsumer.accept(it.getKey().val, it.getValue().val);
         }
     }
 


### PR DESCRIPTION
Addresses issues when this SDK is used together with [grafana/otel-profiling-java](https://github.com/grafana/otel-profiling-java).

See https://github.com/grafana/otel-profiling-java/pull/13 for a detailed description of the issue and the proposed solution.