### PR TITLE
DefaultLogger improvements

### DIFF
--- a/agent/src/main/java/io/pyroscope/javaagent/impl/DefaultLogger.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/impl/DefaultLogger.java
@@ -7,28 +7,29 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
 public class DefaultLogger implements Logger {
-    public static Logger PRECONFIG_LOGGER = new DefaultLogger(Level.DEBUG, System.err);
-    static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-    final Level l;
-    final PrintStream out;
+    public static final Logger PRECONFIG_LOGGER = new DefaultLogger(Level.DEBUG, System.err);
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    private final Level logLevel;
+    private final PrintStream out;
 
-    public DefaultLogger(Level l, PrintStream out) {
-        this.l = l;
+    public DefaultLogger(Level logLevel, PrintStream out) {
+        this.logLevel = logLevel;
         this.out = out;
     }
 
     @Override
-    public void log(Level l, String msg, Object... args) {
-        if (l.level < this.l.level) {
-            return;
-        }
-        String date;
-        synchronized (this) {
-            date = DATE_FORMAT.format(System.currentTimeMillis());
-        }
-        String msg2 = String.format(msg, args);
+	public void log(Level logLevel, String msg, Object... args) {
+		if (logLevel.level < this.logLevel.level) {
+			return;
+		}
+		String date;
+		synchronized (this) {
+			date = DATE_FORMAT.format(System.currentTimeMillis());
+		}
+		String formattedMsg = (msg == null) ? "null"
+				: (args == null || args.length == 0) ? msg : String.format(msg, args);
 
-        out.printf("%s [%s] %s\n", date, l, msg2);
-    }
+		out.printf("%s [%s] %s%n", date, logLevel, formattedMsg);
+	}
 
 }


### PR DESCRIPTION
1. Make **DATE_FORMAT** private since the implementation of _DateFormat_ is not thread safe.
2. Make **DATE_FORMAT**  and **PRECONFIG_LOGGER** final
3. Hide instance variables "logLevel" (renamed from l) and "out"
4. Handle if "msg" is null
5. Use platform independent new-line when formatting log message (%n)