### PR TITLE
labels: switch to besteffort mode once refcounting issue detected

### DIFF
--- a/async-profiler-context/src/main/java/io/pyroscope/labels/Pyroscope.java
+++ b/async-profiler-context/src/main/java/io/pyroscope/labels/Pyroscope.java
@@ -43,6 +43,10 @@ public class Pyroscope {
             }
             RefCounted.contexts.gc();
             RefCounted.strings.gc();
+            if (ScopedContext.isInBestEffortMode()) {
+                RefCounted.contexts.clear();
+                RefCounted.strings.clear();
+            }
             return sb.build();
         }
     }


### PR DESCRIPTION
 https://github.com/grafana/pyroscope-java/issues/70 .
- Instead of assertion error, degrade the labels functionality in case refcounting issue detected. Some labels or labelsets may be missing in the resulting profile.

