### PR TITLE
Address zizmor warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}-latest
@@ -15,7 +18,9 @@ jobs:
         os: [ubuntu, macos]
         java: ['8', '11', '17', '21']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   integration-smoke-test:
     runs-on: ubuntu-latest
@@ -37,7 +40,9 @@ jobs:
           - 'ubuntu-22.04-17'
           - 'ubuntu-22.04-21'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Install Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -5,20 +5,24 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write # pushes to the gh-pages branch
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-java@v1
         with:
           java-version: 11
       - name: Generate Javadoc
         run: ./gradlew javaDoc 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.3.4
+        uses: JamesIves/github-pages-deploy-action@e6d003d0839927f5a4b998bfd92ed8e448fde37a # v4.3.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@fa48192dac470ae356b3f7007229f3ac28c48a25
         with:
           repo_secrets: |
             NEXUS_USERNAME=publishing:nexus_username
@@ -42,9 +42,10 @@ jobs:
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Set up Java 8
         uses: actions/setup-java@v4
@@ -54,12 +55,14 @@ jobs:
 
       - name: Bump Version
         id: bump_version
+        env:
+          VERSION_BUMP: ${{ inputs.version_bump }}
         run: |
           current_version=$(grep 'pyroscope_version=' gradle.properties | cut -d'=' -f2)
           echo "Current version: $current_version"
           IFS='.' read -r major minor patch <<< "$current_version"
 
-          case "${{ inputs.version_bump }}" in
+          case "$VERSION_BUMP" in
             "major")
               major=$((major + 1))
               minor=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,32 +92,41 @@ jobs:
           echo "keyring_path=${{ github.workspace }}/gpg/secring.gpg" >> $GITHUB_OUTPUT
 
       - name: Build and Publish
+        env:
+          NEXUS_GPG_SECRING_FILE: ${{ steps.prepare_gpg_keyring.outputs.keyring_path }}
         run: |
-          export NEXUS_GPG_SECRING_FILE=${{ steps.prepare_gpg_keyring.outputs.keyring_path }}
           make publish
 
       - name: Get GitHub App User ID
         id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          APP_BOT="${APP_SLUG}[bot]"
+          echo "user-id=$(gh api "/users/${APP_BOT}" --jq .id)" >> "$GITHUB_OUTPUT"
 
       - name: Commit Version Bump
-        run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-          git add gradle.properties
-          git commit -m "version ${{ steps.bump_version.outputs.version }}"
-          git tag "v${{ steps.bump_version.outputs.version }}"
-          git push --atomic origin "refs/heads/main" "refs/tags/v${{ steps.bump_version.outputs.version }}"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+          VERSION: ${{ steps.bump_version.outputs.version }}
+        run: |
+          APP_BOT="${APP_SLUG}[bot]"
+          git config --global user.name "${APP_BOT}"
+          git config --global user.email "${USER_ID}+${APP_BOT}@users.noreply.github.com"
+          git add gradle.properties
+          git commit -m "version ${VERSION}"
+          git tag "v${VERSION}"
+          git push --atomic origin "refs/heads/main" "refs/tags/v${VERSION}"
 
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.bump_version.outputs.version }}
         run: |
-          gh release create "v${{ steps.bump_version.outputs.version }}" \
+          gh release create "v${VERSION}" \
             agent/build/libs/pyroscope.jar \
-            --title "Release v${{ steps.bump_version.outputs.version }}" \
+            --title "Release v${VERSION}" \
             --notes "Automated release"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -15,7 +18,9 @@ jobs:
         os: [github-hosted-ubuntu-x64-small , macos-latest]
         java: ['8', '11', '17', '21']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -25,9 +30,10 @@ jobs:
   javadoc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-java@v1
         with:
           java-version: 11


### PR DESCRIPTION
117eef93262aa7cef975643d82063d9b67a8f8e8 addresses errors and warnings
c58498dc1e8c1071dc3f7fe4331ddd8fbb2ab610 addresses low-confidence findings, likely not needed but it makes the actions more consistent and should reduce the noise for future lint checks

```
zizmor .
 INFO zizmor: skipping forbidden-uses: audit not configured
 INFO audit: zizmor: 🌈 completed ./.github/workflows/build.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/itest.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/javadoc.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/release.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test.yml
No findings to report. Good job! (4 suppressed)
```