### PR TITLE
chore(renovate): only open PRs for security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "security:only-security-updates"
+  ]
+}


### PR DESCRIPTION
Mirrors grafana/pyroscope-ruby#71 for pyroscope-java. Adds a project-level `renovate.json` that extends the built-in `security:only-security-updates` preset, so Renovate will stop opening routine version-bump PRs (kotlin, junit, mockito, gradle plugins, base images, gomod for the integration test helpers, etc.) and only file PRs in response to OSV/GHSA advisories. There is no need for the per-package allowlist used in the Ruby repo: `async-profiler` is upgraded manually via `Makefile`/`scripts/download-async-profiler.sh`, and the `grafana/pyroscope` test image is only used as an itest fixture, so neither needs unconditional bumps from Renovate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only Renovate configuration and does not change runtime code. Impact is limited to dependency update PR volume and timing.
> 
> **Overview**
> Adds a project-level `renovate.json` that extends Renovate’s `security:only-security-updates` preset, so Renovate will open PRs only for dependency updates tied to security advisories and stop routine version-bump PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e396b6e5e6c1163d29f766b016ed39c47685deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->