### PR TITLE
chore: bump go toolchain

### DIFF
--- a/itest/go.mod
+++ b/itest/go.mod
@@ -2,4 +2,4 @@ module pyroscope-java-itest
 
 go 1.25.0
 
-toolchain go1.25.6
+toolchain go1.26.3


### PR DESCRIPTION
This should "fix" few "CVE"s

https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/336/version/5178660

<img width="774" height="568" alt="Screenshot 2026-06-01 at 7 16 01 pm" src="https://github.com/user-attachments/assets/561e43f2-ffb3-4cbd-be6a-0975e7a1e054" />
