### PR TITLE
Extend grafana-renovate-config base preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "github>grafana/grafana-renovate-config//presets/base",
     "security:only-security-updates"
   ]
 }


### PR DESCRIPTION
Extend the shared Grafana Renovate base preset, matching [`pyroscope-nodejs`](https://github.com/grafana/pyroscope-nodejs/blob/dd49d5752d35f2e379f0ade867e8c7341f13437f/renovate.json).