### PR TITLE
fix(ci): skip release PR after release merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,6 +31,8 @@ jobs:
           token: ${{ steps.get-github-app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-pull-request: >-
+            ${{ contains(github.event.head_commit.message, 'chore(main): release') }}
 
   publish:
     name: Publish Maven artifacts


### PR DESCRIPTION
## Summary
- Skip release-please PR creation when the merged commit is a release PR commit.
- Keep release creation active for `chore(main): release ...` pushes, matching the Python SDK workflow fix from grafana/pyroscope-python#105.

## Test plan
- `git diff --check -- .github/workflows/release-please.yml`
- `actionlint` unavailable locally; inspected YAML placement under the release-please action inputs.