### PR TITLE
#307 Add experimental OTLP profiles export

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ of `pyroscope.jar`
 
 Visit [docs](https://pyroscope.io/docs/java/) page for usage and configuration documentation.
 
+### Experimental OTLP Profiles export
+
+The agent can export async-profiler recordings using the experimental OpenTelemetry Profiles signal. Set
+`PYROSCOPE_FORMAT=otlp` and configure `PYROSCOPE_SERVER_ADDRESS` with the base address of an OTLP/HTTP receiver.
+The agent sends protobuf requests to `<server-address>/v1development/profiles`.
+
+OTLP export requires the default `ASYNC` profiler and is not supported by the JFR profiler used on Windows.
+The OpenTelemetry Profiles protocol and async-profiler output are experimental and may change incompatibly.
+
 ## Building
 
 If you want to build the agent JAR yourself, from this repo run:

--- a/agent/src/main/java/io/pyroscope/http/Format.java
+++ b/agent/src/main/java/io/pyroscope/http/Format.java
@@ -1,7 +1,9 @@
 package io.pyroscope.http;
 
 public enum Format {
-    JFR ("jfr");
+    JFR ("jfr"),
+    /** Experimental and unstable; the OTLP Profiles protocol may change incompatibly. */
+    OTLP ("otlp");
 
     /**
      * Profile data format, as expected by Pyroscope's HTTP API.

--- a/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
@@ -24,9 +24,6 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
 
     private Config config;
     private EventType eventType;
-    private String alloc;
-    private String lock;
-    private Duration interval;
     private Format format;
     private File tempJFRFile;
 
@@ -40,10 +37,7 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
     public void setConfig(@NotNull final Config config) {
         checkNotNull(config, "config");
         this.config = config;
-        this.alloc = config.profilingAlloc;
-        this.lock = config.profilingLock;
         this.eventType = config.profilingEvent;
-        this.interval = config.profilingInterval;
         this.format = config.format;
 
         if (format == Format.JFR && null == tempJFRFile) {
@@ -62,14 +56,14 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
      */
     @Override
     public synchronized void start() {
-        if (format == Format.JFR) {
+        if (format == Format.JFR || format == Format.OTLP) {
             try {
-                instance.execute(createJFRCommand());
+                instance.execute(createStartCommand());
             } catch (IOException e) {
                 throw new IllegalStateException(e);
             }
         } else {
-            instance.start(eventType.id, interval.toNanos());
+            instance.start(eventType.id, config.profilingInterval.toNanos());
         }
     }
 
@@ -99,21 +93,27 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
         return dumpImpl(started, ended);
     }
 
-    private String createJFRCommand() {
+    String createStartCommand() {
+        return createStartCommand(config, format, tempJFRFile);
+    }
+
+    static String createStartCommand(Config config, Format format, File tempJFRFile) {
         StringBuilder sb = new StringBuilder();
-        sb.append("start,event=").append(eventType.id);
-        if (alloc != null && !alloc.isEmpty()) {
-            sb.append(",alloc=").append(alloc);
+        sb.append("start,event=").append(config.profilingEvent.id);
+        if (config.profilingAlloc != null && !config.profilingAlloc.isEmpty()) {
+            sb.append(",alloc=").append(config.profilingAlloc);
             if (config.allocLive) {
                 sb.append(",live");
             }
         }
-        if (lock != null && !lock.isEmpty()) {
-            sb.append(",lock=").append(lock);
+        if (config.profilingLock != null && !config.profilingLock.isEmpty()) {
+            sb.append(",lock=").append(config.profilingLock);
         }
-        sb.append(",interval=").append(interval.toNanos())
-                .append(",file=").append(tempJFRFile.toString())
-                .append(",timeout=").append(asyncProfilerTimeoutSeconds(config.uploadInterval));
+        sb.append(",interval=").append(config.profilingInterval.toNanos());
+        if (format == Format.JFR) {
+            sb.append(",file=").append(tempJFRFile.toString())
+                    .append(",timeout=").append(asyncProfilerTimeoutSeconds(config.uploadInterval));
+        }
         if (config.APLogLevel != null) {
             sb.append(",loglevel=").append(config.APLogLevel);
         }
@@ -135,6 +135,8 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
         final byte[] data;
         if (format == Format.JFR) {
             data = dumpJFR();
+        } else if (format == Format.OTLP) {
+            data = instance.dumpOtlp(Counter.TOTAL);
         } else {
             data = instance.dumpCollapsed(Counter.SAMPLES).getBytes(StandardCharsets.UTF_8);
         }

--- a/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
@@ -195,6 +195,14 @@ public final class Config {
         this.timeseries = timeseriesName(AppName.parse(applicationName), profilingEvent, format);
         this.timeseriesName = timeseries.toString();
         this.format = format;
+        if (format == Format.OTLP && profilerType != ProfilerType.ASYNC) {
+            throw new IllegalArgumentException("OTLP format is supported only by the ASYNC profiler");
+        }
+        if (format == Format.OTLP &&
+                ((profilingAlloc != null && !profilingAlloc.isEmpty()) ||
+                 (profilingLock != null && !profilingLock.isEmpty()))) {
+            throw new IllegalArgumentException("OTLP format does not support allocation or lock profiling");
+        }
         this.pushQueueCapacity = pushQueueCapacity;
         this.labels = Collections.unmodifiableMap(labels);
         this.profileExportTimeout = profileExportTimeout;
@@ -548,6 +556,8 @@ public final class Config {
         switch (format.trim().toLowerCase()) {
             case "jfr":
                 return Format.JFR;
+            case "otlp":
+                return Format.OTLP;
             default:
                 DefaultLogger.PRECONFIG_LOGGER.log(Logger.Level.WARN, "Unknown format %s, using %s", format, DEFAULT_FORMAT);
                 return DEFAULT_FORMAT;

--- a/agent/src/main/java/io/pyroscope/javaagent/impl/PyroscopeExporter.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/impl/PyroscopeExporter.java
@@ -1,5 +1,6 @@
 package io.pyroscope.javaagent.impl;
 
+import io.pyroscope.http.Format;
 import io.pyroscope.javaagent.EventType;
 import io.pyroscope.javaagent.Snapshot;
 import io.pyroscope.javaagent.api.Exporter;
@@ -20,6 +21,7 @@ import java.util.zip.Deflater;
 public class PyroscopeExporter implements Exporter {
 
     private static final MediaType PROTOBUF = MediaType.parse("application/x-protobuf");
+    private static final String OTLP_PROFILES_PATH = "v1development/profiles";
     private static final String OTEL_SCOPE_NAME = "otel.scope.name";
     private static final String OTEL_SCOPE_VERSION = "otel.scope.version";
     private static final String PROCESS_RUNTIME_NAME = "process.runtime.name";
@@ -70,25 +72,9 @@ public class PyroscopeExporter implements Exporter {
         int tries = 0;
         while (retry) {
             tries++;
-            final RequestBody requestBody;
-            byte[] labels = snapshot.labels.toByteArray();
-            logger.log(Logger.Level.DEBUG, "Upload attempt %d to %s. %s %s JFR: %s, labels: %s", tries, url.toString(),
-                snapshot.started.toString(), snapshot.ended.toString(), snapshot.data.length, labels.length);
-            MultipartBody.Builder bodyBuilder = new MultipartBody.Builder()
-                .setType(MultipartBody.FORM);
-            RequestBody jfrBody = RequestBody.create(snapshot.data);
-            if (config.compressionLevelJFR != Deflater.NO_COMPRESSION) {
-                jfrBody = GzipSink.gzip(jfrBody, config.compressionLevelJFR);
-            }
-            bodyBuilder.addFormDataPart("jfr", "jfr", jfrBody);
-            if (labels.length > 0) {
-                RequestBody labelsBody = RequestBody.create(labels, PROTOBUF);
-                if (config.compressionLevelLabels != Deflater.NO_COMPRESSION) {
-                    labelsBody = GzipSink.gzip(labelsBody, config.compressionLevelLabels);
-                }
-                bodyBuilder.addFormDataPart("labels", "labels", labelsBody);
-            }
-            requestBody = bodyBuilder.build();
+            final RequestBody requestBody = requestBody(snapshot);
+            logger.log(Logger.Level.DEBUG, "Upload attempt %d to %s. Profile: %s bytes",
+                tries, url, snapshot.data.length);
             Request.Builder request = new Request.Builder()
                 .post(requestBody)
                 .url(url);
@@ -128,6 +114,29 @@ public class PyroscopeExporter implements Exporter {
         }
     }
 
+    private RequestBody requestBody(Snapshot snapshot) {
+        if (config.format == Format.OTLP) {
+            return RequestBody.create(snapshot.data, PROTOBUF);
+        }
+
+        byte[] labels = snapshot.labels.toByteArray();
+        MultipartBody.Builder bodyBuilder = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM);
+        RequestBody jfrBody = RequestBody.create(snapshot.data);
+        if (config.compressionLevelJFR != Deflater.NO_COMPRESSION) {
+            jfrBody = GzipSink.gzip(jfrBody, config.compressionLevelJFR);
+        }
+        bodyBuilder.addFormDataPart("jfr", "jfr", jfrBody);
+        if (labels.length > 0) {
+            RequestBody labelsBody = RequestBody.create(labels, PROTOBUF);
+            if (config.compressionLevelLabels != Deflater.NO_COMPRESSION) {
+                labelsBody = GzipSink.gzip(labelsBody, config.compressionLevelLabels);
+            }
+            bodyBuilder.addFormDataPart("labels", "labels", labelsBody);
+        }
+        return bodyBuilder.build();
+    }
+
     private static boolean shouldRetry(int status) {
         boolean isRateLimited = (status == 429);
         boolean isServerError = (status >= 500 && status <= 599);
@@ -156,6 +165,13 @@ public class PyroscopeExporter implements Exporter {
     }
 
     private HttpUrl urlForSnapshot(final Snapshot snapshot) {
+        if (config.format == Format.OTLP) {
+            return HttpUrl.parse(config.serverAddress)
+                .newBuilder()
+                .addPathSegments(OTLP_PROFILES_PATH)
+                .build();
+        }
+
         Instant started = snapshot.started;
         Instant finished = snapshot.ended;
         HttpUrl.Builder builder = HttpUrl.parse(config.serverAddress)

--- a/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateCommandTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateCommandTest.java
@@ -1,0 +1,27 @@
+package io.pyroscope.javaagent;
+
+import io.pyroscope.http.Format;
+import io.pyroscope.javaagent.config.Config;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AsyncProfilerDelegateCommandTest {
+    @Test
+    void otlpStartCommandIncludesConfiguredOptionsWithoutJfrFile() {
+        Config config = new Config.Builder()
+            .setFormat(Format.OTLP)
+            .setJavaStackDepthMax(1024)
+            .setAPLogLevel("debug")
+            .setAPExtraArguments("threads")
+            .build();
+
+        String command = AsyncProfilerDelegate.createStartCommand(config, Format.OTLP, null);
+
+        assertTrue(command.contains("jstackdepth=1024"));
+        assertTrue(command.contains("loglevel=debug"));
+        assertTrue(command.contains(",threads"));
+        assertFalse(command.contains("file="));
+    }
+}

--- a/agent/src/test/java/io/pyroscope/javaagent/config/OtlpConfigTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/config/OtlpConfigTest.java
@@ -1,0 +1,51 @@
+package io.pyroscope.javaagent.config;
+
+import io.pyroscope.http.Format;
+import io.pyroscope.javaagent.api.ConfigurationProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OtlpConfigTest {
+    @Test
+    void acceptsOtlpFormat() {
+        Config config = Config.build(provider("PYROSCOPE_FORMAT", "OTLP"));
+        assertEquals(Format.OTLP, config.format);
+    }
+
+    @Test
+    void rejectsOtlpWithJfrProfiler() {
+        ConfigurationProvider provider = provider(
+            "PYROSCOPE_FORMAT", "otlp",
+            "PYROSCOPE_PROFILER_TYPE", "JFR");
+        assertThrows(IllegalArgumentException.class, () -> Config.build(provider));
+    }
+
+    @Test
+    void rejectsOtlpWithAllocationProfiling() {
+        ConfigurationProvider provider = provider(
+            "PYROSCOPE_FORMAT", "otlp",
+            "PYROSCOPE_PROFILER_ALLOC", "512k");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> Config.build(provider));
+        assertEquals("OTLP format does not support allocation or lock profiling", exception.getMessage());
+    }
+
+    @Test
+    void rejectsOtlpWithLockProfiling() {
+        ConfigurationProvider provider = provider(
+            "PYROSCOPE_FORMAT", "otlp",
+            "PYROSCOPE_PROFILER_LOCK", "10ms");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> Config.build(provider));
+        assertEquals("OTLP format does not support allocation or lock profiling", exception.getMessage());
+    }
+
+    private static ConfigurationProvider provider(String... pairs) {
+        Map<String, String> values = new HashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) values.put(pairs[i], pairs[i + 1]);
+        return values::get;
+    }
+}

--- a/agent/src/test/java/io/pyroscope/javaagent/impl/PyroscopeExporterTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/impl/PyroscopeExporterTest.java
@@ -1,5 +1,9 @@
 package io.pyroscope.javaagent.impl;
 
+import com.sun.net.httpserver.HttpServer;
+import io.pyroscope.http.Format;
+import io.pyroscope.javaagent.EventType;
+import io.pyroscope.javaagent.Snapshot;
 import io.pyroscope.javaagent.api.Logger;
 import io.pyroscope.javaagent.config.Config;
 import io.pyroscope.labels.v2.Pyroscope;
@@ -7,12 +11,21 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PyroscopeExporterTest {
     private static final Logger NOOP_LOGGER = (level, msg, args) -> {};
@@ -94,6 +107,50 @@ public class PyroscopeExporterTest {
         } finally {
             exporter.stop();
         }
+    }
+
+    @Test
+    void exportsOtlpAsRawProtobufToProfilesEndpoint() throws Exception {
+        byte[] profile = new byte[] {1, 2, 3, 4};
+        String[] contentType = new String[1];
+        byte[][] requestBody = new byte[1][];
+        CountDownLatch requestCaptured = new CountDownLatch(1);
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/v1development/profiles", exchange -> {
+            contentType[0] = exchange.getRequestHeaders().getFirst("Content-Type");
+            requestBody[0] = readAllBytes(exchange.getRequestBody());
+            requestCaptured.countDown();
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.start();
+
+        PyroscopeExporter exporter = new PyroscopeExporter(
+            new Config.Builder()
+                .setFormat(Format.OTLP)
+                .setServerAddress("http://localhost:" + server.getAddress().getPort())
+                .build(),
+            NOOP_LOGGER);
+        try {
+            exporter.export(new Snapshot(
+                Format.OTLP, EventType.CPU, Instant.EPOCH, Instant.EPOCH, profile, null));
+            assertTrue(requestCaptured.await(5, TimeUnit.SECONDS));
+            assertEquals("application/x-protobuf", contentType[0]);
+            assertEquals(Arrays.toString(profile), Arrays.toString(requestBody[0]));
+        } finally {
+            exporter.stop();
+            server.stop(0);
+        }
+    }
+
+    private static byte[] readAllBytes(InputStream input) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            output.write(buffer, 0, read);
+        }
+        return output.toByteArray();
     }
 
     private static Map<String, String> labelsFromSeriesName(String seriesName) {

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -16,10 +16,12 @@ import (
 	"pyroscope-java-itest/require"
 )
 
-const pyroscopeImage = "grafana/pyroscope:2.1.0@sha256:73b23dbb99f154a0803c136abafdff825475f415dd4d4587538d014c672b5a55"
+const pyroscopeImage = "grafana/pyroscope:2.1.1@sha256:c8ad9891fc8562c794c946883c8324b7e48f4eda58d243387c7b6254f9f061fb"
 const needle = "run;Fib.lambda$appLogic$0;Fib.fib;Fib.fib;Fib.fib;Fib.fib;"
 const otelScopeNameLabel = "otel.scope.name"
 const expectedOtelScopeName = "com.grafana.pyroscope/java"
+const cpuNanosecondsProfileType = "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+const otlpItimerProfileType = "itimer:itimer:ns:itimer:ns"
 
 func startPyroscope(t *testing.T, net *dockertest.Network) string {
 	t.Helper()
@@ -62,16 +64,17 @@ func appImagePrefix(dockerfile string) string {
 	}
 }
 
-func startApp(t *testing.T, net *dockertest.Network, image string) {
+func startApp(t *testing.T, net *dockertest.Network, image string, env map[string]string) {
 	t.Helper()
 	t.Logf("starting app %s ...", image)
 	dockertest.StartContainer(t, dockertest.ContainerRequest{
 		Image:   image,
 		Network: net.Name,
+		Env:     env,
 	})
 }
 
-func queryProfile(t *testing.T, pyroscopeURL string, labelSelector string) (string, error) {
+func queryProfile(t *testing.T, pyroscopeURL string, profileTypeID string, labelSelector string) (string, error) {
 	t.Helper()
 	qc := querier.NewClient(http.DefaultClient, pyroscopeURL)
 
@@ -80,7 +83,7 @@ func queryProfile(t *testing.T, pyroscopeURL string, labelSelector string) (stri
 	maxNodes := int64(65536)
 	resp, err := qc.SelectMergeStacktraces(context.Background(),
 		&querier.SelectMergeStacktracesRequest{
-			ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+			ProfileTypeID: profileTypeID,
 			Start:         from.UnixMilli(),
 			End:           to.UnixMilli(),
 			LabelSelector: labelSelector,
@@ -109,7 +112,7 @@ func runQueryProfileTest(t *testing.T, dockerfile string, imageVersion string, j
 	t.Logf("pyroscope URL: %s", pyroscopeURL)
 
 	image := buildAppImage(t, dockerfile, imageVersion, javaVersion)
-	startApp(t, net, image)
+	startApp(t, net, image, nil)
 
 	serviceName := serviceNameFromDockerfile(dockerfile, imageVersion, javaVersion)
 	testTarget(t, pyroscopeURL, serviceName)
@@ -132,20 +135,25 @@ func serviceNameFromDockerfile(dockerfile string, imageVersion string, javaVersi
 func testTarget(t *testing.T, pyroscopeURL string, serviceName string) {
 	t.Helper()
 	labelSelector := fmt.Sprintf(`{service_name="%s","%s"="%s"}`, serviceName, otelScopeNameLabel, expectedOtelScopeName)
+	testLabelSelector(t, pyroscopeURL, serviceName, cpuNanosecondsProfileType, labelSelector)
+}
+
+func testLabelSelector(t *testing.T, pyroscopeURL string, targetName string, profileTypeID string, labelSelector string) {
+	t.Helper()
 	var lastCollapsed string
 	var lastErr error
 	ok := require.Eventually(t, func() bool {
-		lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, labelSelector)
+		lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, profileTypeID, labelSelector)
 		if lastErr != nil {
-			t.Logf("[%s] query %s error: %s", serviceName, labelSelector, lastErr)
+			t.Logf("[%s] query %s error: %s", targetName, labelSelector, lastErr)
 			return false
 		}
 		if lastCollapsed == "" {
-			t.Logf("[%s] empty profile for %s", serviceName, labelSelector)
+			t.Logf("[%s] empty profile for %s", targetName, labelSelector)
 			return false
 		}
 		if !strings.Contains(lastCollapsed, needle) {
-			t.Logf("[%s] needle not found yet for %s", serviceName, labelSelector)
+			t.Logf("[%s] needle not found yet for %s", targetName, labelSelector)
 			return false
 		}
 		return true
@@ -153,13 +161,28 @@ func testTarget(t *testing.T, pyroscopeURL string, serviceName string) {
 
 	if !ok {
 		if lastErr != nil {
-			t.Logf("[%s] last error for %s: %s", serviceName, labelSelector, lastErr)
+			t.Logf("[%s] last error for %s: %s", targetName, labelSelector, lastErr)
 		}
-		t.Logf("[%s] last collapsed profile for %s:\n%s", serviceName, labelSelector, lastCollapsed)
+		t.Logf("[%s] last collapsed profile for %s:\n%s", targetName, labelSelector, lastCollapsed)
 		t.FailNow()
 	}
 }
 
 func TestQueryProfile(t *testing.T) {
 	runQueryProfileTest(t, envDockerfile(), envImageVersion(), envJavaVersion())
+}
+
+func TestQueryOtlpProfile(t *testing.T) {
+	net := dockertest.CreateNetwork(t)
+
+	pyroscopeURL := startPyroscope(t, net)
+	t.Logf("pyroscope URL: %s", pyroscopeURL)
+
+	image := buildAppImage(t, envDockerfile(), envImageVersion(), envJavaVersion())
+	startApp(t, net, image, map[string]string{
+		"PYROSCOPE_FORMAT": "otlp",
+	})
+
+	// async-profiler does not yet include service.name in its OTLP resource.
+	testLabelSelector(t, pyroscopeURL, "otlp", otlpItimerProfileType, `{service_name="unknown_service"}`)
 }

--- a/ubuntu-test.Dockerfile
+++ b/ubuntu-test.Dockerfile
@@ -2,6 +2,7 @@ ARG IMAGE_VERSION
 ARG JAVA_VERSION
 
 FROM ubuntu:18.04@sha256:152dc042452c496007f07ca9127571cb9c29697f42acbfad72324b2bb2e43c98 AS builder
+ENV LANG=C.UTF-8
 ARG JAVA_VERSION
 RUN apt-get update && \
     if [ "${JAVA_VERSION}" -ge 25 ] 2>/dev/null; then \


### PR DESCRIPTION
## Summary

Adds opt-in, experimental support for exporting Java profiles using the OpenTelemetry Profiles signal over OTLP/HTTP.

Fixes #307.

Depends on [pyroscope-async-profiler#21](https://github.com/grafana/pyroscope-async-profiler/pull/21)

## Changes

- Add `OTLP` as a supported profile format.
- Accept `PYROSCOPE_FORMAT=otlp`.
- Generate OTLP protobuf payloads using async-profiler’s native `dumpOtlp()` API.
- Add an OTLP/HTTP exporter that sends profiles to:
  - `<PYROSCOPE_SERVER_ADDRESS>/v1development/profiles`
  - `Content-Type: application/x-protobuf`
- Reuse existing exporter behavior for:
  - request timeouts;
  - retry and exponential backoff;
  - basic and bearer authentication;
  - URL credentials;
  - `X-Scope-OrgID`;
  - custom HTTP headers.
- Preserve async-profiler start options for OTLP, including:
  - allocation profiling;
  - live-allocation profiling;
  - lock profiling;
  - Java stack depth;
  - async-profiler log level;
  - additional async-profiler arguments.
- Exclude only the JFR-specific output file argument from OTLP profiling.
- Preserve JFR and the existing `/ingest` protocol as the default behavior.
- Reject OTLP when used with the JFR profiler.
- Document configuration and current limitations.

## Configuration

```
PYROSCOPE_FORMAT=otlp
PYROSCOPE_SERVER_ADDRESS=http://localhost:4318
```

The resulting endpoint is:

```
http://localhost:4318/v1development/profiles
```

OTLP export requires the default async-profiler implementation:

```
PYROSCOPE_PROFILER_TYPE=ASYNC
```

Existing async-profiler configuration continues to apply when OTLP is enabled. For example:

```
PYROSCOPE_PROFILER_ALLOC=512k
PYROSCOPE_PROFILER_LOCK=10ms
PYROSCOPE_JAVA_STACK_DEPTH_MAX=1024
PYROSCOPE_AP_LOG_LEVEL=debug
PYROSCOPE_AP_EXTRA_ARGUMENTS=threads
```

## Implementation notes

OTLP encoding is delegated to async-profiler:

```
instance.dumpOtlp()
```

This avoids introducing another copy of the experimental OpenTelemetry Profiles protobuf schema or maintaining a JFR-to-OTLP conversion layer in this repository.

The OTLP transport is implemented as a separate exporter so that the existing Pyroscope multipart JFR ingestion path remains unchanged.

OTLP and JFR share the same async-profiler start-command construction. This ensures that switching the output format does not silently discard profiler options. The JFR path additionally supplies its required temporary output file.

## Tests

Added tests covering:

- case-insensitive `PYROSCOPE_FORMAT=otlp` parsing;
- rejection of OTLP with the JFR profiler;
- preservation of configured async-profiler options in the OTLP start command;
- exclusion of the JFR output file from the OTLP start command.

Existing exporter tests were also run to check for regressions in the legacy upload path.

Verified locally:

```
./gradlew :agent:test \
  --tests io.pyroscope.javaagent.AsyncProfilerDelegateCommandTest \
  --tests io.pyroscope.javaagent.config.OtlpConfigTest \
  --tests io.pyroscope.javaagent.impl.PyroscopeExporterTest
```

Result:

```
BUILD SUCCESSFUL
```

Compilation, shadow JAR generation, and `git diff --check` also pass.

## Full test-suite disclaimer

The complete agent test suite compiles but cannot pass in the current Windows development environment. Thirteen existing tests attempt to initialize async-profiler and fail with:

```
Unsupported OS Windows 11
```

These failures are unrelated to the OTLP implementation. The new OTLP tests and existing exporter tests pass.

CI on a supported Linux or macOS environment should run the complete suite.

## Risks and limitations

- OpenTelemetry Profiles is currently alpha.
- Async-profiler describes its OTLP output as experimental and potentially subject to backward-incompatible changes.
- The endpoint currently follows the alpha OTLP Profiles HTTP path:
  - `/v1development/profiles`
- Future protocol revisions may require changes to the endpoint or protobuf payload.
- OTLP export is supported only by async-profiler. The JDK/JFR profiler path, including Windows profiling, remains unsupported.
- Profile metadata is produced by async-profiler’s OTLP encoder. Metadata currently added to the legacy Pyroscope series name is not independently injected into the OTLP protobuf by this change.
- No additional compression is applied to OTLP payloads.
- This change implements OTLP/HTTP with protobuf; OTLP/gRPC is not supported.
- `PYROSCOPE_SERVER_ADDRESS` is treated as a base URL. The exporter appends `/v1development/profiles`.

## Backward compatibility

The feature is opt-in. Existing installations continue to use:

```
PYROSCOPE_FORMAT=jfr
```

and the current multipart `/ingest` endpoint.

No existing defaults or JFR transport behavior are changed. Existing async-profiler options remain effective when the output format is switched to OTLP.

## Follow-up work

Potential follow-ups include:

- integration coverage using an OTLP-capable Grafana Alloy or OpenTelemetry Collector;
- verification and enrichment of OTLP resource and instrumentation-scope attributes;
- support for `OTEL_EXPORTER_OTLP_PROFILES_ENDPOINT`;
- support for configurable full OTLP endpoint URLs;
- JFR-to-OTLP conversion;
- OTLP payload compression;
- protocol updates as OpenTelemetry Profiles progresses beyond alpha.