### PR TITLE
fix: Set async-profiler timeout for JFR recordings

### DIFF
--- a/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
@@ -103,7 +103,8 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
             sb.append(",lock=").append(lock);
         }
         sb.append(",interval=").append(interval.toNanos())
-                .append(",file=").append(tempJFRFile.toString());
+                .append(",file=").append(tempJFRFile.toString())
+                .append(",timeout=").append(config.uploadInterval.getSeconds());
         if (config.APLogLevel != null) {
             sb.append(",loglevel=").append(config.APLogLevel);
         }

--- a/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
@@ -82,7 +82,7 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
             instance.stop();
         } catch (IllegalStateException e) {
             // async-profiler throws when stop is called after the JFR timeout has already elapsed.
-            if (format != Format.JFR || !PROFILER_NOT_ACTIVE.equals(e.getMessage())) {
+            if (!PROFILER_NOT_ACTIVE.equals(e.getMessage())) {
                 throw e;
             }
         }

--- a/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
@@ -20,6 +20,9 @@ import java.time.Instant;
 import static io.pyroscope.Preconditions.checkNotNull;
 
 public final class AsyncProfilerDelegate implements ProfilerDelegate {
+    private static final int TIMEOUT_SAFETY_MULTIPLIER = 2;
+    private static final String PROFILER_NOT_ACTIVE = "Profiler is not active";
+
     private Config config;
     private EventType eventType;
     private String alloc;
@@ -76,7 +79,13 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
      */
     @Override
     public synchronized void stop() {
-        instance.stop();
+        try {
+            instance.stop();
+        } catch (IllegalStateException e) {
+            if (format != Format.JFR || !PROFILER_NOT_ACTIVE.equals(e.getMessage())) {
+                throw e;
+            }
+        }
     }
 
     /**
@@ -104,7 +113,7 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
         }
         sb.append(",interval=").append(interval.toNanos())
                 .append(",file=").append(tempJFRFile.toString())
-                .append(",timeout=").append(config.uploadInterval.getSeconds());
+                .append(",timeout=").append(asyncProfilerTimeoutSeconds(config.uploadInterval));
         if (config.APLogLevel != null) {
             sb.append(",loglevel=").append(config.APLogLevel);
         }
@@ -113,6 +122,15 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
             sb.append(",").append(config.APExtraArguments);
         }
         return sb.toString();
+    }
+
+    static long asyncProfilerTimeoutSeconds(Duration profilingDuration) {
+        Duration timeout = profilingDuration.multipliedBy(TIMEOUT_SAFETY_MULTIPLIER);
+        long seconds = timeout.getSeconds();
+        if (timeout.getNano() > 0) {
+            seconds++;
+        }
+        return Math.max(1, seconds);
     }
 
     private Snapshot dumpImpl(Instant started, Instant ended) {

--- a/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
@@ -20,7 +20,6 @@ import java.time.Instant;
 import static io.pyroscope.Preconditions.checkNotNull;
 
 public final class AsyncProfilerDelegate implements ProfilerDelegate {
-    private static final int TIMEOUT_SAFETY_MULTIPLIER = 2;
     private static final String PROFILER_NOT_ACTIVE = "Profiler is not active";
 
     private Config config;
@@ -82,6 +81,7 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
         try {
             instance.stop();
         } catch (IllegalStateException e) {
+            // async-profiler throws when stop is called after the JFR timeout has already elapsed.
             if (format != Format.JFR || !PROFILER_NOT_ACTIVE.equals(e.getMessage())) {
                 throw e;
             }
@@ -125,9 +125,8 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
     }
 
     static long asyncProfilerTimeoutSeconds(Duration profilingDuration) {
-        Duration timeout = profilingDuration.multipliedBy(TIMEOUT_SAFETY_MULTIPLIER);
-        long seconds = timeout.getSeconds();
-        if (timeout.getNano() > 0) {
+        long seconds = profilingDuration.getSeconds();
+        if (profilingDuration.getNano() > 0) {
             seconds++;
         }
         return Math.max(1, seconds);

--- a/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
@@ -125,11 +125,7 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
     }
 
     static long asyncProfilerTimeoutSeconds(Duration profilingDuration) {
-        long seconds = profilingDuration.getSeconds();
-        if (profilingDuration.getNano() > 0) {
-            seconds++;
-        }
-        return Math.max(1, seconds);
+        return profilingDuration.getSeconds() + 1;
     }
 
     private Snapshot dumpImpl(Instant started, Instant ended) {

--- a/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateTest.java
@@ -1,0 +1,21 @@
+package io.pyroscope.javaagent;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AsyncProfilerDelegateTest {
+
+    @Test
+    void timeoutHasSafetyMargin() {
+        assertEquals(20, AsyncProfilerDelegate.asyncProfilerTimeoutSeconds(Duration.ofSeconds(10)));
+    }
+
+    @Test
+    void timeoutRoundsUpToWholeSeconds() {
+        assertEquals(3, AsyncProfilerDelegate.asyncProfilerTimeoutSeconds(Duration.ofMillis(1500)));
+        assertEquals(1, AsyncProfilerDelegate.asyncProfilerTimeoutSeconds(Duration.ofMillis(1)));
+    }
+}

--- a/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateTest.java
@@ -9,8 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class AsyncProfilerDelegateTest {
 
     @Test
-    void timeoutUsesExactWholeSeconds() {
-        assertEquals(10, AsyncProfilerDelegate.asyncProfilerTimeoutSeconds(Duration.ofSeconds(10)));
+    void timeoutAddsOneSecond() {
+        assertEquals(11, AsyncProfilerDelegate.asyncProfilerTimeoutSeconds(Duration.ofSeconds(10)));
     }
 
     @Test

--- a/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateTest.java
@@ -9,13 +9,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class AsyncProfilerDelegateTest {
 
     @Test
-    void timeoutHasSafetyMargin() {
-        assertEquals(20, AsyncProfilerDelegate.asyncProfilerTimeoutSeconds(Duration.ofSeconds(10)));
+    void timeoutUsesExactWholeSeconds() {
+        assertEquals(10, AsyncProfilerDelegate.asyncProfilerTimeoutSeconds(Duration.ofSeconds(10)));
     }
 
     @Test
     void timeoutRoundsUpToWholeSeconds() {
-        assertEquals(3, AsyncProfilerDelegate.asyncProfilerTimeoutSeconds(Duration.ofMillis(1500)));
+        assertEquals(2, AsyncProfilerDelegate.asyncProfilerTimeoutSeconds(Duration.ofMillis(1500)));
         assertEquals(1, AsyncProfilerDelegate.asyncProfilerTimeoutSeconds(Duration.ofMillis(1)));
     }
 }


### PR DESCRIPTION
This adds an async-profiler timeout to JFR recording commands based on the configured upload interval. It provides a safety net if the scheduled stop does not run, preventing the recording file from growing indefinitely. Related to #338.