### PR TITLE
feat: configuration for custom temporary file paths

### DIFF
--- a/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
@@ -1,8 +1,9 @@
 package io.pyroscope.javaagent;
 
+import io.pyroscope.PyroscopeAsyncProfiler;
 import io.pyroscope.http.Format;
 import io.pyroscope.javaagent.config.Config;
-import io.pyroscope.PyroscopeAsyncProfiler;
+import io.pyroscope.javaagent.util.TmpFileUtil;
 import io.pyroscope.labels.v2.Pyroscope;
 import one.profiler.AsyncProfiler;
 import one.profiler.Counter;
@@ -10,14 +11,13 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 
-
 import static io.pyroscope.Preconditions.checkNotNull;
+import static java.nio.file.Files.newInputStream;
 
 public final class AsyncProfilerDelegate implements ProfilerDelegate {
     private Config config;
@@ -46,8 +46,7 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
 
         if (format == Format.JFR && null == tempJFRFile) {
             try {
-                // flight recorder is built on top of a file descriptor, so we need a file.
-                tempJFRFile = File.createTempFile("pyroscope", ".jfr");
+                tempJFRFile = TmpFileUtil.createJfrFile(config);
                 tempJFRFile.deleteOnExit();
             } catch (IOException e) {
                 throw new IllegalStateException(e);
@@ -137,7 +136,7 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
     private byte[] dumpJFR() {
         try {
             byte[] bytes = new byte[(int) tempJFRFile.length()];
-            try (DataInputStream ds = new DataInputStream(new FileInputStream(tempJFRFile))) {
+            try (DataInputStream ds = new DataInputStream(newInputStream(tempJFRFile.toPath()))) {
                 ds.readFully(bytes);
             }
             return bytes;

--- a/agent/src/main/java/io/pyroscope/javaagent/BootstrapApiInjector.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/BootstrapApiInjector.java
@@ -1,13 +1,18 @@
 package io.pyroscope.javaagent;
 
 import io.pyroscope.javaagent.api.Logger;
+import io.pyroscope.javaagent.impl.DefaultConfigurationProvider;
 import io.pyroscope.javaagent.impl.DefaultLogger;
+import io.pyroscope.javaagent.util.TmpFileUtil;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.instrument.Instrumentation;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.jar.JarFile;
 
@@ -34,8 +39,27 @@ import java.util.jar.JarFile;
 class BootstrapApiInjector {
 
     private static final String RESOURCE_NAME = "/pyroscope-bootstrap.jar.bin";
+    private static final String PYROSCOPE_TMP_DIR = "PYROSCOPE_TMP_DIR";
 
     static void inject(Instrumentation instrumentation) {
+        String s = getTmpDir();
+        Path tmpDir = null;
+        if (s != null && !s.isEmpty()) {
+            try {
+                tmpDir = Paths.get(s);
+            } catch (InvalidPathException e) {
+                DefaultLogger.PRECONFIG_LOGGER.log(Logger.Level.WARN,
+                    "BootstrapApiInjector: invalid PYROSCOPE_TMP_DIR '%s', using system temp: %s", s, e.getMessage());
+            }
+        }
+        inject(instrumentation, tmpDir);
+    }
+
+    private static String getTmpDir() {
+        return DefaultConfigurationProvider.INSTANCE.get(PYROSCOPE_TMP_DIR);
+    }
+
+    static void inject(Instrumentation instrumentation, @Nullable Path tmpDir) {
         try {
             try (InputStream is = BootstrapApiInjector.class.getResourceAsStream(RESOURCE_NAME)) {
                 if (is == null) {
@@ -44,7 +68,7 @@ class BootstrapApiInjector {
                         RESOURCE_NAME);
                     return;
                 }
-                Path tempJar = Files.createTempFile("pyroscope-bootstrap-", ".jar");
+                Path tempJar = createBootstrapJar(tmpDir);
                 tempJar.toFile().deleteOnExit();
                 Files.copy(is, tempJar, StandardCopyOption.REPLACE_EXISTING);
 
@@ -56,5 +80,9 @@ class BootstrapApiInjector {
             DefaultLogger.PRECONFIG_LOGGER.log(Logger.Level.ERROR,
                 "BootstrapApiInjector: Failed to inject bootstrap API: %s", e);
         }
+    }
+
+    private static Path createBootstrapJar(@Nullable Path tmpDir) throws IOException {
+        return TmpFileUtil.createTempFile(tmpDir, "pyroscope-bootstrap-", ".jar").toPath();
     }
 }

--- a/agent/src/main/java/io/pyroscope/javaagent/JFRJCMDProfilerDelegate.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/JFRJCMDProfilerDelegate.java
@@ -2,6 +2,7 @@ package io.pyroscope.javaagent;
 
 import io.pyroscope.http.Format;
 import io.pyroscope.javaagent.config.Config;
+import io.pyroscope.javaagent.util.TmpFileUtil;
 import io.pyroscope.labels.v2.Pyroscope;
 
 import java.io.BufferedReader;
@@ -48,7 +49,7 @@ public final class JFRJCMDProfilerDelegate implements ProfilerDelegate {
         jfrSettingsPath = findJfrSettingsPath(config);
 
         try {
-            tempJFRFile = File.createTempFile("pyroscope", ".jfr");
+            tempJFRFile = TmpFileUtil.createJfrFile(config);
             tempJFRFile.deleteOnExit();
         } catch (IOException e) {
             throw new IllegalStateException(e);
@@ -141,7 +142,8 @@ public final class JFRJCMDProfilerDelegate implements ProfilerDelegate {
         }
         // otherwise load default settings
         try (InputStream inputStream = JFRJCMDProfilerDelegate.class.getResourceAsStream(JFR_SETTINGS_RESOURCE)) {
-            Path jfrSettingsPath = Files.createTempFile("pyroscope", ".jfc");
+            Path jfrSettingsPath = TmpFileUtil.createTempFile(config.tmpDir, "pyroscope", ".jfc").toPath();
+            jfrSettingsPath.toFile().deleteOnExit();
             Files.copy(inputStream, jfrSettingsPath, StandardCopyOption.REPLACE_EXISTING);
             return jfrSettingsPath;
         } catch (IOException e) {

--- a/agent/src/main/java/io/pyroscope/javaagent/JFRJDKProfilerDelegate.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/JFRJDKProfilerDelegate.java
@@ -2,6 +2,7 @@ package io.pyroscope.javaagent;
 
 import io.pyroscope.http.Format;
 import io.pyroscope.javaagent.config.Config;
+import io.pyroscope.javaagent.util.TmpFileUtil;
 import jdk.jfr.Recording;
 
 import java.io.File;
@@ -11,9 +12,8 @@ import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Optional;
 
-import static io.pyroscope.labels.v2.Pyroscope.*;
+import static io.pyroscope.labels.v2.Pyroscope.LabelsWrapper;
 import static java.lang.String.format;
 
 /**
@@ -37,16 +37,11 @@ public final class JFRJDKProfilerDelegate implements ProfilerDelegate {
     public void setConfig(final Config config) {
         this.config = config;
         try {
-            tempJFRFile = jfrRecordingPath();
+            tempJFRFile = TmpFileUtil.createJfrFile(config);
+            tempJFRFile.deleteOnExit();
         } catch (IOException e) {
             throw new UncheckedIOException("cannot create JFR destination path", e);
         }
-    }
-
-    private static File jfrRecordingPath() throws IOException {
-        File tempJFRFile = File.createTempFile("pyroscope", ".jfr");
-        tempJFRFile.deleteOnExit();
-        return tempJFRFile;
     }
 
     /**

--- a/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
@@ -11,10 +11,12 @@ import io.pyroscope.javaagent.impl.DefaultConfigurationProvider;
 import io.pyroscope.javaagent.impl.DefaultLogger;
 import okhttp3.HttpUrl;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.*;
@@ -58,6 +60,7 @@ public final class Config {
     private static final String PYROSCOPE_HTTP_HEADERS = "PYROSCOPE_HTTP_HEADERS";
     private static final String PYROSCOPE_TENANT_ID = "PYROSCOPE_TENANT_ID";
     private static final String PYROSCOPE_PROFILE_EXPORT_TIMEOUT = "PYROSCOPE_PROFILE_EXPORT_TIMEOUT";
+    private static final String PYROSCOPE_TMP_DIR = "PYROSCOPE_TMP_DIR";
 
     /**
      * Experimental feature, may be removed in the future
@@ -137,6 +140,7 @@ public final class Config {
     public final String APExtraArguments;
     public final String basicAuthUser;
     public final String basicAuthPassword;
+    public final @Nullable Path tmpDir;
 
     Config(final boolean agentEnabled,
            final String applicationName,
@@ -166,7 +170,8 @@ public final class Config {
            String APExtraArguments,
            String basicAuthUser,
            String basicAuthPassword,
-           Duration profileExportTimeout) {
+           Duration profileExportTimeout,
+           @Nullable Path tmpDir) {
         this.agentEnabled = agentEnabled;
         this.applicationName = applicationName;
         this.profilerType = profilerType;
@@ -192,6 +197,7 @@ public final class Config {
         this.APExtraArguments = APExtraArguments;
         this.basicAuthUser = basicAuthUser;
         this.basicAuthPassword = basicAuthPassword;
+        this.tmpDir = validateTmpDir(tmpDir);
         this.timeseries = timeseriesName(AppName.parse(applicationName), profilingEvent, format);
         this.timeseriesName = timeseries.toString();
         this.format = format;
@@ -250,6 +256,7 @@ public final class Config {
                ", httpHeaders=" + httpHeaders +
                ", samplingDuration=" + samplingDuration +
                ", tenantID=" + tenantID +
+               ", tmpDir='" + tmpDir + '\'' +
                '}';
     }
 
@@ -305,7 +312,8 @@ public final class Config {
             cp.get(PYROSCOPE_AP_LOG_LEVEL_CONFIG),
             cp.get(PYROSCOPE_AP_EXTRA_ARGUMENTS_CONFIG),
             cp.get(PYROSCOPE_BASIC_AUTH_USER_CONFIG), cp.get(PYROSCOPE_BASIC_AUTH_PASSWORD_CONFIG),
-            profileExportTimeout(cp));
+            profileExportTimeout(cp),
+            tmpDir(cp));
     }
 
     /**
@@ -659,6 +667,19 @@ public final class Config {
         return cp.get(PYROSCOPE_TENANT_ID);
     }
 
+    private static @Nullable Path tmpDir(ConfigurationProvider cp) {
+        String s = cp.get(PYROSCOPE_TMP_DIR);
+        return (s != null && !s.isEmpty()) ? Paths.get(s) : null;
+    }
+
+    private static @Nullable Path validateTmpDir(@Nullable Path tmpDir) {
+        if (tmpDir != null && tmpDir.toAbsolutePath().toString().contains(",")) {
+            throw new IllegalArgumentException(
+                "PYROSCOPE_TMP_DIR must not contain commas — async-profiler uses comma as option separator: " + tmpDir);
+        }
+        return tmpDir;
+    }
+
     private static Duration samplingDuration(ConfigurationProvider configurationProvider) {
         Duration uploadInterval = uploadInterval(configurationProvider);
 
@@ -730,6 +751,7 @@ public final class Config {
         private String basicAuthUser;
         private String basicAuthPassword;
         private String jfrProfilerSettings;
+        private @Nullable Path tmpDir;
 
         public Builder() {
         }
@@ -766,6 +788,7 @@ public final class Config {
             APExtraArguments = buildUpon.APExtraArguments;
             basicAuthUser = buildUpon.basicAuthUser;
             basicAuthPassword = buildUpon.basicAuthPassword;
+            tmpDir = buildUpon.tmpDir;
         }
 
         public Builder setAgentEnabled(boolean agentEnabled) {
@@ -940,6 +963,12 @@ public final class Config {
             return this;
         }
 
+        public Builder setTmpDir(@Nullable String tmpDir) {
+            this.tmpDir = validateTmpDir(
+                (tmpDir != null && !tmpDir.isEmpty()) ? Paths.get(tmpDir) : null);
+            return this;
+        }
+
         public @NotNull Config build() {
             if (applicationName == null || applicationName.isEmpty()) {
                 applicationName = generateApplicationName();
@@ -972,7 +1001,8 @@ public final class Config {
                 APLogLevel,
                 APExtraArguments,
                 basicAuthUser, basicAuthPassword,
-                profileExportTimeout);
+                profileExportTimeout,
+                tmpDir);
         }
     }
 }

--- a/agent/src/main/java/io/pyroscope/javaagent/util/TmpFileUtil.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/util/TmpFileUtil.java
@@ -1,0 +1,27 @@
+package io.pyroscope.javaagent.util;
+
+import io.pyroscope.javaagent.config.Config;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class TmpFileUtil {
+    private TmpFileUtil() {
+    }
+
+    public static File createJfrFile(Config config) throws IOException {
+        return createTempFile(config.tmpDir, "pyroscope", ".jfr");
+    }
+
+    public static File createTempFile(@Nullable Path dir, String prefix, String suffix) throws IOException {
+        if (dir != null) {
+            Files.createDirectories(dir);
+            return Files.createTempFile(dir, prefix, suffix).toFile().getAbsoluteFile();
+        }
+        return File.createTempFile(prefix, suffix).getAbsoluteFile();
+    }
+}

--- a/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateJfrDirTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateJfrDirTest.java
@@ -1,0 +1,75 @@
+package io.pyroscope.javaagent;
+
+import io.pyroscope.http.Format;
+import io.pyroscope.javaagent.config.Config;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AsyncProfilerDelegateJfrDirTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testJFRFileCreatedInConfiguredDirectory() throws Exception {
+        String jfrDir = tempDir.toString();
+        Config config = new Config.Builder()
+            .setFormat(Format.JFR)
+            .setTmpDir(jfrDir)
+            .build();
+
+        AsyncProfilerDelegate delegate = new AsyncProfilerDelegate(config);
+
+        java.lang.reflect.Field field = AsyncProfilerDelegate.class.getDeclaredField("tempJFRFile");
+        field.setAccessible(true);
+        java.io.File jfrFile = (java.io.File) field.get(delegate);
+
+        assertNotNull(jfrFile);
+        assertTrue(jfrFile.getAbsolutePath().startsWith(jfrDir),
+            "JFR file should be created in the configured directory");
+        assertTrue(jfrFile.getAbsolutePath().endsWith(".jfr"),
+            "JFR file should have .jfr extension");
+    }
+
+    @Test
+    void testJFRFileCreatedInDefaultDirectoryWhenNotConfigured() throws Exception {
+        Config config = new Config.Builder()
+            .setFormat(Format.JFR)
+            .setTmpDir(null)
+            .build();
+
+        AsyncProfilerDelegate delegate = new AsyncProfilerDelegate(config);
+
+        java.lang.reflect.Field field = AsyncProfilerDelegate.class.getDeclaredField("tempJFRFile");
+        field.setAccessible(true);
+        java.io.File jfrFile = (java.io.File) field.get(delegate);
+
+        assertNotNull(jfrFile);
+        assertTrue(jfrFile.getAbsolutePath().endsWith(".jfr"),
+            "JFR file should have .jfr extension");
+    }
+
+    @Test
+    void testConfiguredDirectoryIsCreatedIfNotExists() throws Exception {
+        Path jfrDir = tempDir.resolve("nested/async/profiler/dir");
+        assertFalse(Files.exists(jfrDir), "Test directory should not exist initially");
+
+        Config config = new Config.Builder()
+            .setFormat(Format.JFR)
+            .setTmpDir(jfrDir.toString())
+            .build();
+
+        AsyncProfilerDelegate delegate = new AsyncProfilerDelegate(config);
+
+        assertTrue(Files.exists(jfrDir),
+            "Configured directory should be created");
+        assertTrue(Files.isDirectory(jfrDir),
+            "Created path should be a directory");
+    }
+
+}

--- a/agent/src/test/java/io/pyroscope/javaagent/BootstrapApiInjectorJfrDirTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/BootstrapApiInjectorJfrDirTest.java
@@ -1,0 +1,166 @@
+package io.pyroscope.javaagent;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class BootstrapApiInjectorJfrDirTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        System.clearProperty("PYROSCOPE_TMP_DIR");
+        System.clearProperty("pyroscope.tmp.dir");
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("PYROSCOPE_TMP_DIR");
+        System.clearProperty("pyroscope.tmp.dir");
+    }
+
+    @Test
+    void testBootstrapJarCanBeCreatedInConfiguredDirectory() throws IOException {
+        Instrumentation instrumentation = mock(Instrumentation.class);
+
+        assertDoesNotThrow(() -> {
+            BootstrapApiInjector.class
+                .getDeclaredMethod("inject", Instrumentation.class, Path.class)
+                .invoke(null, instrumentation, tempDir);
+        });
+    }
+
+    @Test
+    void testBootstrapJarCanBeCreatedWithNullDirectory() throws IOException {
+        Instrumentation instrumentation = mock(Instrumentation.class);
+
+        assertDoesNotThrow(() -> {
+            BootstrapApiInjector.class
+                .getDeclaredMethod("inject", Instrumentation.class, Path.class)
+                .invoke(null, instrumentation, (Object) null);
+        });
+    }
+
+    @Test
+    void testConfiguredDirectoryIsCreatedForBootstrapJar() throws Exception {
+        Path jfrDir = tempDir.resolve("bootstrap/jar/dir");
+        assertFalse(Files.exists(jfrDir), "Test directory should not exist initially");
+
+        testCreateBootstrapJarMethod(jfrDir);
+
+        assertTrue(Files.exists(jfrDir),
+            "Configured directory should be created for bootstrap JAR");
+        assertTrue(Files.isDirectory(jfrDir),
+            "Created path should be a directory");
+    }
+
+    @Test
+    void testBootstrapJarNameStartsWithPyroscope() throws Exception {
+        Path jfrDir = tempDir.resolve("bootstrap");
+        Files.createDirectories(jfrDir);
+
+        testCreateBootstrapJarMethod(jfrDir);
+
+        boolean foundBootstrapJar = Files.walk(jfrDir)
+            .map(Path::getFileName)
+            .map(Path::toString)
+            .anyMatch(name -> name.startsWith("pyroscope-bootstrap-") && name.endsWith(".jar"));
+
+        assertTrue(foundBootstrapJar,
+            "Bootstrap JAR file should start with 'pyroscope-bootstrap-' and end with '.jar'");
+    }
+
+    private void testCreateBootstrapJarMethod(Path jfrDir) throws Exception {
+        java.lang.reflect.Method method = BootstrapApiInjector.class.getDeclaredMethod("createBootstrapJar", Path.class);
+        method.setAccessible(true);
+        Path result = (Path) method.invoke(null, jfrDir);
+
+        assertNotNull(result);
+        assertTrue(result.toString().contains(jfrDir.toString()),
+            "Bootstrap JAR should be created in the configured directory");
+    }
+
+    @Test
+    void testGetJfrDirFromSystemProperty() throws Exception {
+        String jfrDir = tempDir.toString();
+        System.setProperty("PYROSCOPE_TMP_DIR", jfrDir);
+
+        java.lang.reflect.Method method = BootstrapApiInjector.class.getDeclaredMethod("getTmpDir");
+        method.setAccessible(true);
+        String result = (String) method.invoke(null);
+
+        assertEquals(jfrDir, result,
+            "Should read PYROSCOPE_TMP_DIR from system property (-D flag)");
+    }
+
+    @Test
+    void testGetJfrDirPrefersSystemPropertyOverEnv() throws Exception {
+        String jfrDir = tempDir.toString();
+        System.setProperty("PYROSCOPE_TMP_DIR", jfrDir);
+
+        java.lang.reflect.Method method = BootstrapApiInjector.class.getDeclaredMethod("getTmpDir");
+        method.setAccessible(true);
+        String result = (String) method.invoke(null);
+
+        assertEquals(jfrDir, result,
+            "System property should take precedence over environment variable");
+    }
+
+    @Test
+    void testGetJfrDirFromDottedLowercaseSystemProperty() throws Exception {
+        // e.g. java -Dpyroscope.tmp.dir=/path -javaagent:pyroscope.jar ...
+        // must match the convention used by -Dpyroscope.application.name etc.
+        String jfrDir = tempDir.toString();
+        System.setProperty("pyroscope.tmp.dir", jfrDir);
+
+        java.lang.reflect.Method method = BootstrapApiInjector.class.getDeclaredMethod("getTmpDir");
+        method.setAccessible(true);
+        String result = (String) method.invoke(null);
+
+        assertEquals(jfrDir, result,
+            "Should read -Dpyroscope.tmp.dir just like other -Dpyroscope.* properties");
+    }
+
+    @Test
+    void testGetJfrDirPrefersUppercaseSystemPropertyOverDottedLowercase() throws Exception {
+        String uppercaseDir = tempDir.resolve("uppercase").toString();
+        String dottedDir = tempDir.resolve("dotted").toString();
+        System.setProperty("PYROSCOPE_TMP_DIR", uppercaseDir);
+        System.setProperty("pyroscope.tmp.dir", dottedDir);
+
+        java.lang.reflect.Method method = BootstrapApiInjector.class.getDeclaredMethod("getTmpDir");
+        method.setAccessible(true);
+        String result = (String) method.invoke(null);
+
+        assertEquals(uppercaseDir, result,
+            "Exact-case PYROSCOPE_TMP_DIR system property should win over the dotted-lowercase form");
+    }
+
+    @Test
+    void testGetJfrDirFallsBackToNull() throws Exception {
+        System.clearProperty("PYROSCOPE_TMP_DIR");
+
+        java.lang.reflect.Method method = BootstrapApiInjector.class.getDeclaredMethod("getTmpDir");
+        method.setAccessible(true);
+        String result = (String) method.invoke(null);
+
+        assertNull(result,
+            "Should return null when no property or env var is set");
+    }
+}

--- a/agent/src/test/java/io/pyroscope/javaagent/JFRJCMDProfilerDelegateJfrDirTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/JFRJCMDProfilerDelegateJfrDirTest.java
@@ -1,0 +1,115 @@
+package io.pyroscope.javaagent;
+
+import io.pyroscope.javaagent.config.Config;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JFRJCMDProfilerDelegateJfrDirTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testJFRFileCreatedInConfiguredDirectory() throws IOException {
+        String jfrDir = tempDir.toString();
+        Config config = new Config.Builder()
+            .setTmpDir(jfrDir)
+            .build();
+
+        JFRJCMDProfilerDelegate delegate = new JFRJCMDProfilerDelegate(config);
+
+        assertNotNull(delegate);
+        File jfrFile = getPrivateFieldValue(delegate, "tempJFRFile");
+
+        assertNotNull(jfrFile);
+        assertTrue(jfrFile.getAbsolutePath().startsWith(jfrDir),
+            "JFR file should be created in the configured directory");
+        assertTrue(jfrFile.getAbsolutePath().endsWith(".jfr"),
+            "JFR file should have .jfr extension");
+    }
+
+    @Test
+    void testJFRFileCreatedInDefaultDirectoryWhenNotConfigured() throws IOException {
+        Config config = new Config.Builder()
+            .setTmpDir(null)
+            .build();
+
+        JFRJCMDProfilerDelegate delegate = new JFRJCMDProfilerDelegate(config);
+
+        assertNotNull(delegate);
+        File jfrFile = getPrivateFieldValue(delegate, "tempJFRFile");
+
+        assertNotNull(jfrFile);
+        assertTrue(jfrFile.getAbsolutePath().endsWith(".jfr"),
+            "JFR file should have .jfr extension");
+    }
+
+    @Test
+    void testJFRFileCreatedInDefaultDirectoryWhenEmptyString() throws IOException {
+        Config config = new Config.Builder()
+            .setTmpDir("")
+            .build();
+
+        JFRJCMDProfilerDelegate delegate = new JFRJCMDProfilerDelegate(config);
+
+        assertNotNull(delegate);
+        File jfrFile = getPrivateFieldValue(delegate, "tempJFRFile");
+
+        assertNotNull(jfrFile);
+        assertTrue(jfrFile.getAbsolutePath().endsWith(".jfr"),
+            "JFR file should have .jfr extension");
+    }
+
+    @Test
+    void testConfiguredDirectoryIsCreatedIfNotExists() throws IOException {
+        Path jfrDir = tempDir.resolve("nested/jfr/directory");
+        assertFalse(Files.exists(jfrDir), "Test directory should not exist initially");
+
+        Config config = new Config.Builder()
+            .setTmpDir(jfrDir.toString())
+            .build();
+
+        JFRJCMDProfilerDelegate delegate = new JFRJCMDProfilerDelegate(config);
+
+        assertNotNull(delegate);
+        assertTrue(Files.exists(jfrDir),
+            "Configured directory should be created");
+        assertTrue(Files.isDirectory(jfrDir),
+            "Created path should be a directory");
+    }
+
+    @Test
+    void testJFRFileNameStartsWithPyroscope() throws IOException {
+        String jfrDir = tempDir.toString();
+        Config config = new Config.Builder()
+            .setTmpDir(jfrDir)
+            .build();
+
+        JFRJCMDProfilerDelegate delegate = new JFRJCMDProfilerDelegate(config);
+
+        File jfrFile = getPrivateFieldValue(delegate, "tempJFRFile");
+        String fileName = jfrFile.getName();
+
+        assertTrue(fileName.startsWith("pyroscope"),
+            "JFR file name should start with 'pyroscope'");
+    }
+
+    private <T> T getPrivateFieldValue(Object obj, String fieldName) {
+        try {
+            java.lang.reflect.Field field = obj.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return (T) field.get(obj);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/agent/src/test/java/io/pyroscope/javaagent/JFRJDKProfilerDelegateJfrDirTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/JFRJDKProfilerDelegateJfrDirTest.java
@@ -1,0 +1,106 @@
+package io.pyroscope.javaagent;
+
+import io.pyroscope.javaagent.config.Config;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JFRJDKProfilerDelegateJfrDirTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testJFRFileCreatedInConfiguredDirectory() throws Exception {
+        String jfrDir = tempDir.toString();
+        Config config = new Config.Builder()
+            .setTmpDir(jfrDir)
+            .build();
+
+        JFRJDKProfilerDelegate delegate = new JFRJDKProfilerDelegate(config);
+
+        java.lang.reflect.Field field = JFRJDKProfilerDelegate.class.getDeclaredField("tempJFRFile");
+        field.setAccessible(true);
+        File jfrFile = (File) field.get(delegate);
+
+        assertNotNull(jfrFile);
+        assertTrue(jfrFile.getAbsolutePath().startsWith(jfrDir),
+            "JFR file should be created in the configured directory");
+        assertTrue(jfrFile.getAbsolutePath().endsWith(".jfr"),
+            "JFR file should have .jfr extension");
+    }
+
+    @Test
+    void testJFRFileCreatedInDefaultDirectoryWhenNotConfigured() throws Exception {
+        Config config = new Config.Builder()
+            .setTmpDir(null)
+            .build();
+
+        JFRJDKProfilerDelegate delegate = new JFRJDKProfilerDelegate(config);
+
+        java.lang.reflect.Field field = JFRJDKProfilerDelegate.class.getDeclaredField("tempJFRFile");
+        field.setAccessible(true);
+        File jfrFile = (File) field.get(delegate);
+
+        assertNotNull(jfrFile);
+        assertTrue(jfrFile.getAbsolutePath().endsWith(".jfr"),
+            "JFR file should have .jfr extension");
+    }
+
+    @Test
+    void testJFRFileCreatedInDefaultDirectoryWhenEmptyString() throws Exception {
+        Config config = new Config.Builder()
+            .setTmpDir("")
+            .build();
+
+        JFRJDKProfilerDelegate delegate = new JFRJDKProfilerDelegate(config);
+
+        java.lang.reflect.Field field = JFRJDKProfilerDelegate.class.getDeclaredField("tempJFRFile");
+        field.setAccessible(true);
+        File jfrFile = (File) field.get(delegate);
+
+        assertNotNull(jfrFile);
+        assertTrue(jfrFile.getAbsolutePath().endsWith(".jfr"),
+            "JFR file should have .jfr extension");
+    }
+
+    @Test
+    void testConfiguredDirectoryIsCreatedIfNotExists() throws Exception {
+        Path jfrDir = tempDir.resolve("nested/jdk/jfr/directory");
+        assertFalse(Files.exists(jfrDir), "Test directory should not exist initially");
+
+        Config config = new Config.Builder()
+            .setTmpDir(jfrDir.toString())
+            .build();
+
+        JFRJDKProfilerDelegate delegate = new JFRJDKProfilerDelegate(config);
+
+        assertTrue(Files.exists(jfrDir),
+            "Configured directory should be created");
+        assertTrue(Files.isDirectory(jfrDir),
+            "Created path should be a directory");
+    }
+
+    @Test
+    void testJFRFileNameStartsWithPyroscope() throws Exception {
+        String jfrDir = tempDir.toString();
+        Config config = new Config.Builder()
+            .setTmpDir(jfrDir)
+            .build();
+
+        JFRJDKProfilerDelegate delegate = new JFRJDKProfilerDelegate(config);
+
+        java.lang.reflect.Field field = JFRJDKProfilerDelegate.class.getDeclaredField("tempJFRFile");
+        field.setAccessible(true);
+        File jfrFile = (File) field.get(delegate);
+
+        String fileName = jfrFile.getName();
+        assertTrue(fileName.startsWith("pyroscope"),
+            "JFR file name should start with 'pyroscope'");
+    }
+}

--- a/agent/src/test/java/io/pyroscope/javaagent/config/ConfigJfrDirTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/config/ConfigJfrDirTest.java
@@ -1,0 +1,182 @@
+package io.pyroscope.javaagent.config;
+
+import io.pyroscope.javaagent.api.ConfigurationProvider;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConfigJfrDirTest {
+
+    @Test
+    void testConfigBuilderWithJfrDir() {
+        String testDir = "/custom/jfr/path";
+        Config config = new Config.Builder()
+            .setTmpDir(testDir)
+            .build();
+
+        assertEquals(testDir, config.tmpDir.toString());
+    }
+
+    @Test
+    void testConfigBuilderWithoutJfrDir() {
+        Config config = new Config.Builder()
+            .build();
+
+        assertNull(config.tmpDir);
+    }
+
+    @Test
+    void testConfigBuilderWithEmptyJfrDir() {
+        Config config = new Config.Builder()
+            .setTmpDir("")
+            .build();
+
+        assertNull(config.tmpDir);
+    }
+
+    @Test
+    void testConfigBuildFromConfigurationProviderWithJfrDir() {
+        ConfigurationProvider cp = mock(ConfigurationProvider.class);
+        when(cp.get("PYROSCOPE_AGENT_ENABLED")).thenReturn(null);
+        when(cp.get("PYROSCOPE_APPLICATION_NAME")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILER_TYPE")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILING_INTERVAL")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILER_EVENT")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILER_ALLOC")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILER_LOCK")).thenReturn(null);
+        when(cp.get("PYROSCOPE_UPLOAD_INTERVAL")).thenReturn(null);
+        when(cp.get("PYROSCOPE_JAVA_STACK_DEPTH_MAX")).thenReturn(null);
+        when(cp.get("PYROSCOPE_LOG_LEVEL")).thenReturn(null);
+        when(cp.get("PYROSCOPE_SERVER_ADDRESS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_AUTH_TOKEN")).thenReturn(null);
+        when(cp.get("PYROSCOPE_JFR_PROFILER_SETTINGS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_FORMAT")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PUSH_QUEUE_CAPACITY")).thenReturn(null);
+        when(cp.get("PYROSCOPE_LABELS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_INGEST_MAX_TRIES")).thenReturn(null);
+        when(cp.get("PYROSCOPE_EXPORT_COMPRESSION_LEVEL_JFR")).thenReturn(null);
+        when(cp.get("PYROSCOPE_EXPORT_COMPRESSION_LEVEL_LABELS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_ALLOC_LIVE")).thenReturn(null);
+        when(cp.get("PYROSCOPE_GC_BEFORE_DUMP")).thenReturn(null);
+        when(cp.get("PYROSCOPE_HTTP_HEADERS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_SAMPLING_DURATION")).thenReturn(null);
+        when(cp.get("PYROSCOPE_TENANT_ID")).thenReturn(null);
+        when(cp.get("PYROSCOPE_AP_LOG_LEVEL")).thenReturn(null);
+        when(cp.get("PYROSCOPE_AP_EXTRA_ARGUMENTS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_BASIC_AUTH_USER")).thenReturn(null);
+        when(cp.get("PYROSCOPE_BASIC_AUTH_PASSWORD")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILE_EXPORT_TIMEOUT")).thenReturn(null);
+
+        String testDir = "/var/lib/pyroscope/jfr";
+        when(cp.get("PYROSCOPE_TMP_DIR")).thenReturn(testDir);
+
+        Config config = Config.build(cp);
+
+        assertEquals(testDir, config.tmpDir.toString());
+    }
+
+    @Test
+    void testConfigBuildFromConfigurationProviderWithoutJfrDir() {
+        ConfigurationProvider cp = mock(ConfigurationProvider.class);
+        when(cp.get("PYROSCOPE_AGENT_ENABLED")).thenReturn(null);
+        when(cp.get("PYROSCOPE_APPLICATION_NAME")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILER_TYPE")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILING_INTERVAL")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILER_EVENT")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILER_ALLOC")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILER_LOCK")).thenReturn(null);
+        when(cp.get("PYROSCOPE_UPLOAD_INTERVAL")).thenReturn(null);
+        when(cp.get("PYROSCOPE_JAVA_STACK_DEPTH_MAX")).thenReturn(null);
+        when(cp.get("PYROSCOPE_LOG_LEVEL")).thenReturn(null);
+        when(cp.get("PYROSCOPE_SERVER_ADDRESS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_AUTH_TOKEN")).thenReturn(null);
+        when(cp.get("PYROSCOPE_JFR_PROFILER_SETTINGS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_FORMAT")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PUSH_QUEUE_CAPACITY")).thenReturn(null);
+        when(cp.get("PYROSCOPE_LABELS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_INGEST_MAX_TRIES")).thenReturn(null);
+        when(cp.get("PYROSCOPE_EXPORT_COMPRESSION_LEVEL_JFR")).thenReturn(null);
+        when(cp.get("PYROSCOPE_EXPORT_COMPRESSION_LEVEL_LABELS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_ALLOC_LIVE")).thenReturn(null);
+        when(cp.get("PYROSCOPE_GC_BEFORE_DUMP")).thenReturn(null);
+        when(cp.get("PYROSCOPE_HTTP_HEADERS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_SAMPLING_DURATION")).thenReturn(null);
+        when(cp.get("PYROSCOPE_TENANT_ID")).thenReturn(null);
+        when(cp.get("PYROSCOPE_AP_LOG_LEVEL")).thenReturn(null);
+        when(cp.get("PYROSCOPE_AP_EXTRA_ARGUMENTS")).thenReturn(null);
+        when(cp.get("PYROSCOPE_BASIC_AUTH_USER")).thenReturn(null);
+        when(cp.get("PYROSCOPE_BASIC_AUTH_PASSWORD")).thenReturn(null);
+        when(cp.get("PYROSCOPE_PROFILE_EXPORT_TIMEOUT")).thenReturn(null);
+        when(cp.get("PYROSCOPE_TMP_DIR")).thenReturn(null);
+
+        Config config = Config.build(cp);
+
+        assertNull(config.tmpDir);
+    }
+
+    @Test
+    void testSetTmpDirRejectsAbsolutePathWithComma() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new Config.Builder().setTmpDir("/tmp/my,dir"));
+    }
+
+    @Test
+    void testSetTmpDirRejectsRelativePathWithCommaInSegment() {
+        // relative path — comma is in the configured string itself and in the resolved absolute path
+        assertThrows(IllegalArgumentException.class, () ->
+            new Config.Builder().setTmpDir("../my,dir/pyroscope"));
+    }
+
+    @Test
+    void testSetTmpDirRejectsRelativePathWhoseResolvedFormHasComma() {
+        // construct a relative path whose absolute form will contain a comma by
+        // prepending one level up from the real CWD and re-entering via a comma segment
+        String cwd = Paths.get("").toAbsolutePath().toString();
+        String relativeWithCommaInParent = "../" + "dir,with,commas";
+        // The resolved path is cwd.parent + "/dir,with,commas" — it always contains a comma
+        assertThrows(IllegalArgumentException.class, () ->
+            new Config.Builder().setTmpDir(relativeWithCommaInParent));
+    }
+
+    @Test
+    void testConfigBuildRejectsCommaViaConfigurationProvider() {
+        ConfigurationProvider cp = mock(ConfigurationProvider.class);
+        when(cp.get("PYROSCOPE_TMP_DIR")).thenReturn("/var/lib/my,pyroscope");
+        assertThrows(IllegalArgumentException.class, () -> Config.build(cp));
+    }
+
+    @Test
+    void testNewBuilderPreservesJfrDir() {
+        String testDir = "/custom/jfr/path";
+        Config original = new Config.Builder()
+            .setTmpDir(testDir)
+            .build();
+
+        Config copy = original.newBuilder()
+            .build();
+
+        assertEquals(testDir, copy.tmpDir.toString());
+    }
+
+    @Test
+    void testConfigNewBuilderCanOverrideJfrDir() {
+        String originalDir = "/original/path";
+        String newDir = "/new/path";
+
+        Config original = new Config.Builder()
+            .setTmpDir(originalDir)
+            .build();
+
+        Config updated = original.newBuilder()
+            .setTmpDir(newDir)
+            .build();
+
+        assertEquals(newDir, updated.tmpDir.toString());
+    }
+}

--- a/agent/src/test/java/io/pyroscope/javaagent/util/TmpFileUtilTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/util/TmpFileUtilTest.java
@@ -1,0 +1,113 @@
+package io.pyroscope.javaagent.util;
+
+import io.pyroscope.javaagent.config.Config;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TmpFileUtilTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testCreateJfrFileInConfiguredDirectory() throws Exception {
+        String tmpDir = tempDir.toString();
+        Config config = new Config.Builder()
+            .setTmpDir(tmpDir)
+            .build();
+
+        File jfrFile = TmpFileUtil.createJfrFile(config);
+
+        assertNotNull(jfrFile);
+        assertTrue(jfrFile.getAbsolutePath().startsWith(tmpDir),
+            "JFR file should be created in the configured directory");
+        assertTrue(jfrFile.getAbsolutePath().endsWith(".jfr"),
+            "JFR file should have .jfr extension");
+    }
+
+    @Test
+    void testCreateJfrFileInDefaultDirectoryWhenNotConfigured() throws Exception {
+        Config config = new Config.Builder()
+            .setTmpDir(null)
+            .build();
+
+        File jfrFile = TmpFileUtil.createJfrFile(config);
+
+        assertNotNull(jfrFile);
+        assertTrue(jfrFile.getAbsolutePath().endsWith(".jfr"),
+            "JFR file should have .jfr extension");
+    }
+
+    @Test
+    void testCreateJfrFileInDefaultDirectoryWhenEmptyString() throws Exception {
+        Config config = new Config.Builder()
+            .setTmpDir("")
+            .build();
+
+        File jfrFile = TmpFileUtil.createJfrFile(config);
+
+        assertNotNull(jfrFile);
+        assertTrue(jfrFile.getAbsolutePath().endsWith(".jfr"),
+            "JFR file should have .jfr extension");
+    }
+
+    @Test
+    void testDirectoriesCreatedIfNotExists() throws Exception {
+        Path tmpDir = tempDir.resolve("deeply/nested/jfr/directory");
+        assertFalse(Files.exists(tmpDir), "Test directory should not exist initially");
+
+        Config config = new Config.Builder()
+            .setTmpDir(tmpDir.toString())
+            .build();
+
+        File jfrFile = TmpFileUtil.createJfrFile(config);
+
+        assertTrue(Files.exists(tmpDir),
+            "Configured directory should be created");
+        assertTrue(Files.isDirectory(tmpDir),
+            "Created path should be a directory");
+        assertTrue(jfrFile.getAbsolutePath().startsWith(tmpDir.toString()),
+            "JFR file should be in the created directory");
+    }
+
+    @Test
+    void testMultipleFilesInSameDirectory() throws Exception {
+        String tmpDir = tempDir.toString();
+        Config config = new Config.Builder()
+            .setTmpDir(tmpDir)
+            .build();
+
+        File jfrFile1 = TmpFileUtil.createJfrFile(config);
+        File jfrFile2 = TmpFileUtil.createJfrFile(config);
+
+        assertNotNull(jfrFile1);
+        assertNotNull(jfrFile2);
+        assertNotEquals(jfrFile1.getAbsolutePath(), jfrFile2.getAbsolutePath(),
+            "Each call should create a new unique file");
+        assertTrue(Files.exists(jfrFile1.toPath()),
+            "First file should exist");
+        assertTrue(Files.exists(jfrFile2.toPath()),
+            "Second file should exist");
+    }
+
+    @Test
+    void testJfrFileNamePattern() throws Exception {
+        Config config = new Config.Builder()
+            .setTmpDir(tempDir.toString())
+            .build();
+
+        File jfrFile = TmpFileUtil.createJfrFile(config);
+        String fileName = jfrFile.getName();
+
+        assertTrue(fileName.startsWith("pyroscope"),
+            "JFR file name should start with 'pyroscope'");
+        assertTrue(fileName.endsWith(".jfr"),
+            "JFR file name should end with '.jfr'");
+    }
+}


### PR DESCRIPTION
Support config driven locations for .jfr files and bootstrap jars to avoid them going into the /tmp dir for apps that want to control this. 