### PR TITLE
fix: warn about ignored OTLP application name and labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,6 @@ of `pyroscope.jar`
 
 Visit [docs](https://pyroscope.io/docs/java/) page for usage and configuration documentation.
 
-### Experimental OTLP Profiles export
-
-The agent can export async-profiler recordings using the experimental OpenTelemetry Profiles signal. Set
-`PYROSCOPE_FORMAT=otlp` and configure `PYROSCOPE_SERVER_ADDRESS` with the base address of an OTLP/HTTP receiver.
-The agent sends protobuf requests to `<server-address>/v1development/profiles`.
-
-OTLP export requires the default `ASYNC` profiler and is not supported by the JFR profiler used on Windows.
-Only one profiling event can run at a time. Allocation and lock thresholds can be configured when their event is
-selected, for example with `PYROSCOPE_PROFILER_EVENT=alloc` and `PYROSCOPE_PROFILER_ALLOC=512k`. Multiple events
-remain supported in sampling mode because they run sequentially.
-The OpenTelemetry Profiles protocol and async-profiler output are experimental and may change incompatibly.
-
 ## Building
 
 If you want to build the agent JAR yourself, from this repo run:

--- a/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
@@ -147,6 +147,8 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
                 started,
                 ended,
                 data,
+                // This also removes closed scoped contexts. Keep draining them even though the
+                // current OTLP exporter does not include the resulting labels snapshot.
                 Pyroscope.LabelsWrapper.dump()
         );
     }

--- a/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/PyroscopeAgent.java
@@ -1,5 +1,6 @@
 package io.pyroscope.javaagent;
 
+import io.pyroscope.http.Format;
 import io.pyroscope.javaagent.api.Exporter;
 import io.pyroscope.javaagent.api.Logger;
 import io.pyroscope.javaagent.api.ProfilingScheduler;
@@ -59,6 +60,11 @@ public class PyroscopeAgent {
             }
             sOptions = options;
             logger.log(Logger.Level.DEBUG, "Config: %s", options.config);
+            if (options.config.format == Format.OTLP) {
+                logger.log(Logger.Level.WARN,
+                    "OTLP export does not include the configured application name or labels; " +
+                    "profiles may appear under service_name=\"unknown_service\"");
+            }
             try {
                 options.scheduler.start(options.profiler);
                 ScopedContext.ENABLED.set(true);

--- a/agent/src/test/java/io/pyroscope/javaagent/PyroscopeAgentTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/PyroscopeAgentTest.java
@@ -1,5 +1,6 @@
 package io.pyroscope.javaagent;
 
+import io.pyroscope.http.Format;
 import io.pyroscope.javaagent.api.Logger;
 import io.pyroscope.javaagent.api.ProfilingScheduler;
 import io.pyroscope.javaagent.config.Config;
@@ -27,6 +28,9 @@ public class PyroscopeAgentTest {
     @Mock
     private ProfilingScheduler profilingScheduler;
 
+    @Mock
+    private ProfilerDelegate profiler;
+
     @BeforeEach
     void setUp() {
         configAgentEnabled = new Config.Builder()
@@ -35,6 +39,7 @@ public class PyroscopeAgentTest {
         optionsAgentEnabled = new PyroscopeAgent.Options.Builder(configAgentEnabled)
             .setScheduler(profilingScheduler)
             .setLogger(logger)
+            .setProfiler(profiler)
             .build();
 
         configAgentDisabled = new Config.Builder()
@@ -43,6 +48,7 @@ public class PyroscopeAgentTest {
         optionsAgentDisabled = new PyroscopeAgent.Options.Builder(configAgentDisabled)
             .setScheduler(profilingScheduler)
             .setLogger(logger)
+            .setProfiler(profiler)
             .build();
     }
 
@@ -56,6 +62,7 @@ public class PyroscopeAgentTest {
         PyroscopeAgent.start(optionsAgentEnabled);
 
         verify(profilingScheduler, times(1)).start(any());
+        verify(logger, never()).log(eq(Logger.Level.WARN), contains("OTLP export"));
     }
 
     @Test
@@ -63,5 +70,25 @@ public class PyroscopeAgentTest {
         PyroscopeAgent.start(optionsAgentDisabled);
 
         verify(profilingScheduler, never()).start(any());
+    }
+
+    @Test
+    void warnsWhenOtlpDoesNotIncludeApplicationNameOrLabels() {
+        Config config = new Config.Builder()
+            .setAgentEnabled(true)
+            .setFormat(Format.OTLP)
+            .build();
+        PyroscopeAgent.Options options = new PyroscopeAgent.Options.Builder(config)
+            .setScheduler(profilingScheduler)
+            .setLogger(logger)
+            .setProfiler(profiler)
+            .build();
+
+        PyroscopeAgent.start(options);
+
+        verify(logger).log(
+            Logger.Level.WARN,
+            "OTLP export does not include the configured application name or labels; " +
+            "profiles may appear under service_name=\"unknown_service\"");
     }
 }


### PR DESCRIPTION
Documents the current OTLP export limitation and warns users that the configured application name and labels are not included in OTLP profiles. These profiles may therefore appear under `service_name="unknown_service"`.

It also clarifies why `LabelsWrapper.dump()` is still called in OTLP mode: besides producing the labels snapshot, it removes closed scoped contexts and prevents them from accumulating.

## Changes

- Document the OTLP application name and label limitation in the README.
- Log a warning at startup when OTLP export is enabled.
- Add tests covering the warning.
- Isolate `PyroscopeAgentTest` from native async-profiler initialization to make it portable across operating systems.
- Explain why label state is drained even though OTLP export currently ignores the resulting snapshot.

## Testing

```
./gradlew :agent:test --tests io.pyroscope.javaagent.PyroscopeAgentTest

3 tests completed, 0 failed
BUILD SUCCESSFUL
```

Closes #344.