### PR TITLE
fix: allow OTLP allocation and lock thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The agent can export async-profiler recordings using the experimental OpenTeleme
 The agent sends protobuf requests to `<server-address>/v1development/profiles`.
 
 OTLP export requires the default `ASYNC` profiler and is not supported by the JFR profiler used on Windows.
+Only one profiling event can run at a time. Allocation and lock thresholds can be configured when their event is
+selected, for example with `PYROSCOPE_PROFILER_EVENT=alloc` and `PYROSCOPE_PROFILER_ALLOC=512k`. Multiple events
+remain supported in sampling mode because they run sequentially.
 The OpenTelemetry Profiles protocol and async-profiler output are experimental and may change incompatibly.
 
 ## Building

--- a/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/config/Config.java
@@ -204,10 +204,11 @@ public final class Config {
         if (format == Format.OTLP && profilerType != ProfilerType.ASYNC) {
             throw new IllegalArgumentException("OTLP format is supported only by the ASYNC profiler");
         }
-        if (format == Format.OTLP &&
-                ((profilingAlloc != null && !profilingAlloc.isEmpty()) ||
-                 (profilingLock != null && !profilingLock.isEmpty()))) {
-            throw new IllegalArgumentException("OTLP format does not support allocation or lock profiling");
+        final boolean sequentialSampling = samplingDuration != null && samplingEventOrder != null;
+        if (format == Format.OTLP && !sequentialSampling &&
+                ((profilingAlloc != null && !profilingAlloc.isEmpty() && profilingEvent != EventType.ALLOC) ||
+                 (profilingLock != null && !profilingLock.isEmpty() && profilingEvent != EventType.LOCK))) {
+            throw new IllegalArgumentException("OTLP format does not support multiple profiling events simultaneously");
         }
         this.pushQueueCapacity = pushQueueCapacity;
         this.labels = Collections.unmodifiableMap(labels);

--- a/agent/src/test/java/io/pyroscope/javaagent/config/OtlpConfigTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/config/OtlpConfigTest.java
@@ -1,6 +1,7 @@
 package io.pyroscope.javaagent.config;
 
 import io.pyroscope.http.Format;
+import io.pyroscope.javaagent.EventType;
 import io.pyroscope.javaagent.api.ConfigurationProvider;
 import org.junit.jupiter.api.Test;
 
@@ -26,21 +27,52 @@ class OtlpConfigTest {
     }
 
     @Test
-    void rejectsOtlpWithAllocationProfiling() {
+    void acceptsOtlpWithAllocationProfiling() {
+        Config config = Config.build(provider(
+            "PYROSCOPE_FORMAT", "otlp",
+            "PYROSCOPE_PROFILER_EVENT", "alloc",
+            "PYROSCOPE_PROFILER_ALLOC", "512k"));
+        assertEquals(EventType.ALLOC, config.profilingEvent);
+        assertEquals("512k", config.profilingAlloc);
+    }
+
+    @Test
+    void acceptsOtlpWithLockProfiling() {
+        Config config = Config.build(provider(
+            "PYROSCOPE_FORMAT", "otlp",
+            "PYROSCOPE_PROFILER_EVENT", "lock",
+            "PYROSCOPE_PROFILER_LOCK", "10ms"));
+        assertEquals(EventType.LOCK, config.profilingEvent);
+        assertEquals("10ms", config.profilingLock);
+    }
+
+    @Test
+    void rejectsOtlpWithSimultaneousAllocationProfiling() {
         ConfigurationProvider provider = provider(
             "PYROSCOPE_FORMAT", "otlp",
             "PYROSCOPE_PROFILER_ALLOC", "512k");
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> Config.build(provider));
-        assertEquals("OTLP format does not support allocation or lock profiling", exception.getMessage());
+        assertEquals("OTLP format does not support multiple profiling events simultaneously", exception.getMessage());
     }
 
     @Test
-    void rejectsOtlpWithLockProfiling() {
+    void rejectsOtlpWithSimultaneousLockProfiling() {
         ConfigurationProvider provider = provider(
             "PYROSCOPE_FORMAT", "otlp",
             "PYROSCOPE_PROFILER_LOCK", "10ms");
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> Config.build(provider));
-        assertEquals("OTLP format does not support allocation or lock profiling", exception.getMessage());
+        assertEquals("OTLP format does not support multiple profiling events simultaneously", exception.getMessage());
+    }
+
+    @Test
+    void acceptsOtlpWithSequentialSamplingEvents() {
+        Config config = Config.build(provider(
+            "PYROSCOPE_FORMAT", "otlp",
+            "PYROSCOPE_PROFILER_ALLOC", "512k",
+            "PYROSCOPE_PROFILER_LOCK", "10ms",
+            "PYROSCOPE_SAMPLING_DURATION", "1s",
+            "PYROSCOPE_SAMPLING_EVENT_ORDER", "cpu,alloc,lock"));
+        assertEquals(3, config.samplingEventOrder.size());
     }
 
     private static ConfigurationProvider provider(String... pairs) {


### PR DESCRIPTION
## Description

Allows OTLP export to use allocation and lock profiling thresholds when the threshold configures the selected primary event.

Valid configurations now include:

```text
PYROSCOPE_FORMAT=otlp
PYROSCOPE_PROFILER_EVENT=alloc
PYROSCOPE_PROFILER_ALLOC=512k
```

and:

```text
PYROSCOPE_FORMAT=otlp
PYROSCOPE_PROFILER_EVENT=lock
PYROSCOPE_PROFILER_LOCK=10ms
```

Previously, any use of `PYROSCOPE_PROFILER_ALLOC` or `PYROSCOPE_PROFILER_LOCK` with OTLP was rejected, even though async-profiler treats these values as thresholds for the selected event.

The validation still rejects distinct events running simultaneously. Multiple events remain supported in sampling mode, where they run sequentially.

## Changes

- Allow allocation thresholds when `alloc` is the primary event.
- Allow lock thresholds when `lock` is the primary event.
- Preserve validation against simultaneous OTLP profiling events.
- Add coverage for allocation, lock, invalid simultaneous events, and sequential sampling.
- Document the supported OTLP configurations.

## Testing

```shell
./gradlew :agent:test --tests io.pyroscope.javaagent.config.OtlpConfigTest
```

Fixes #347 