### PR TITLE
fix: compress OTLP profile uploads

### DIFF
--- a/agent/src/main/java/io/pyroscope/javaagent/impl/PyroscopeExporter.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/impl/PyroscopeExporter.java
@@ -81,6 +81,10 @@ public class PyroscopeExporter implements Exporter {
 
             config.httpHeaders.forEach((k, v) -> request.header(k, v));
 
+            if (config.format == Format.OTLP && config.compressionLevelJFR != Deflater.NO_COMPRESSION) {
+                request.header("Content-Encoding", "gzip");
+            }
+
             addAuthHeader(request, url, config);
 
 
@@ -116,7 +120,11 @@ public class PyroscopeExporter implements Exporter {
 
     private RequestBody requestBody(Snapshot snapshot) {
         if (config.format == Format.OTLP) {
-            return RequestBody.create(snapshot.data, PROTOBUF);
+            RequestBody body = RequestBody.create(snapshot.data, PROTOBUF);
+            if (config.compressionLevelJFR != Deflater.NO_COMPRESSION) {
+                body = GzipSink.gzip(body, config.compressionLevelJFR);
+            }
+            return body;
         }
 
         byte[] labels = snapshot.labels.toByteArray();

--- a/agent/src/test/java/io/pyroscope/javaagent/impl/PyroscopeExporterTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/impl/PyroscopeExporterTest.java
@@ -11,18 +11,20 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPInputStream;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -110,14 +112,16 @@ public class PyroscopeExporterTest {
     }
 
     @Test
-    void exportsOtlpAsRawProtobufToProfilesEndpoint() throws Exception {
+    void exportsOtlpAsGzippedProtobufToProfilesEndpoint() throws Exception {
         byte[] profile = new byte[] {1, 2, 3, 4};
         String[] contentType = new String[1];
+        String[] contentEncoding = new String[1];
         byte[][] requestBody = new byte[1][];
         CountDownLatch requestCaptured = new CountDownLatch(1);
         HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
         server.createContext("/v1development/profiles", exchange -> {
             contentType[0] = exchange.getRequestHeaders().getFirst("Content-Type");
+            contentEncoding[0] = exchange.getRequestHeaders().getFirst("Content-Encoding");
             requestBody[0] = readAllBytes(exchange.getRequestBody());
             requestCaptured.countDown();
             exchange.sendResponseHeaders(200, -1);
@@ -136,7 +140,9 @@ public class PyroscopeExporterTest {
                 Format.OTLP, EventType.CPU, Instant.EPOCH, Instant.EPOCH, profile, null));
             assertTrue(requestCaptured.await(5, TimeUnit.SECONDS));
             assertEquals("application/x-protobuf", contentType[0]);
-            assertEquals(Arrays.toString(profile), Arrays.toString(requestBody[0]));
+            assertEquals("gzip", contentEncoding[0]);
+            assertArrayEquals(profile, readAllBytes(new GZIPInputStream(
+                new ByteArrayInputStream(requestBody[0]))));
         } finally {
             exporter.stop();
             server.stop(0);


### PR DESCRIPTION
## Summary

Fixes #346 by compressing OTLP profile uploads with gzip.

- Reuses the existing `compressionLevelJFR` configuration.
- Adds `Content-Encoding: gzip` when compression is enabled.
- Preserves `application/x-protobuf` as the content type.
- Keeps `NO_COMPRESSION` behavior unchanged.
- Updates the exporter test to verify the header and decompressed payload.

## Testing

```shell
./gradlew :agent:test --tests io.pyroscope.javaagent.impl.PyroscopeExporterTest --rerun-tasks
```

Result: `BUILD SUCCESSFUL`