### PR TITLE
fix: set async-profiler timeout for OTLP recordings

### DIFF
--- a/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
+++ b/agent/src/main/java/io/pyroscope/javaagent/AsyncProfilerDelegate.java
@@ -74,7 +74,7 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
         try {
             instance.stop();
         } catch (IllegalStateException e) {
-            // async-profiler throws when stop is called after the JFR timeout has already elapsed.
+            // async-profiler throws when stop is called after the recording timeout has already elapsed.
             if (!PROFILER_NOT_ACTIVE.equals(e.getMessage())) {
                 throw e;
             }
@@ -110,8 +110,10 @@ public final class AsyncProfilerDelegate implements ProfilerDelegate {
         }
         sb.append(",interval=").append(config.profilingInterval.toNanos());
         if (format == Format.JFR) {
-            sb.append(",file=").append(tempJFRFile.toString())
-                    .append(",timeout=").append(asyncProfilerTimeoutSeconds(config.uploadInterval));
+            sb.append(",file=").append(tempJFRFile.toString());
+        }
+        if (format == Format.JFR || format == Format.OTLP) {
+            sb.append(",timeout=").append(asyncProfilerTimeoutSeconds(config.uploadInterval));
         }
         if (config.APLogLevel != null) {
             sb.append(",loglevel=").append(config.APLogLevel);

--- a/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateCommandTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateCommandTest.java
@@ -4,6 +4,8 @@ import io.pyroscope.http.Format;
 import io.pyroscope.javaagent.config.Config;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -15,6 +17,7 @@ class AsyncProfilerDelegateCommandTest {
             .setJavaStackDepthMax(1024)
             .setAPLogLevel("debug")
             .setAPExtraArguments("threads")
+            .setUploadInterval(Duration.ofSeconds(10))
             .build();
 
         String command = AsyncProfilerDelegate.createStartCommand(config, Format.OTLP, null);
@@ -22,6 +25,7 @@ class AsyncProfilerDelegateCommandTest {
         assertTrue(command.contains("jstackdepth=1024"));
         assertTrue(command.contains("loglevel=debug"));
         assertTrue(command.contains(",threads"));
+        assertTrue(command.contains("timeout=11"));
         assertFalse(command.contains("file="));
     }
 }


### PR DESCRIPTION
## Description

Adds an async-profiler recording timeout for OTLP mode.

Previously, `timeout` was only included for JFR recordings. If scheduler ticks stalled while using OTLP, the in-memory recording could grow without a bound.

The OTLP start command now uses the existing upload-interval-derived timeout while continuing to omit the JFR-only `file` option.

## Testing

```text
./gradlew.bat :agent:test \
  --tests io.pyroscope.javaagent.AsyncProfilerDelegateCommandTest \
  --tests io.pyroscope.javaagent.AsyncProfilerDelegateTest
```

Result: `BUILD SUCCESSFUL`

Fixes #345.