### PR TITLE
Add security reporting guidance

### DIFF
--- a/itest/CLAUDE.md
+++ b/itest/CLAUDE.md
@@ -1,2 +1,3 @@
 ## Go dependencies
 - Prefer to not add go dependencies
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
