### PR TITLE
test: cover async-profiler JFR start command

### DIFF
--- a/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateCommandTest.java
+++ b/agent/src/test/java/io/pyroscope/javaagent/AsyncProfilerDelegateCommandTest.java
@@ -4,12 +4,27 @@ import io.pyroscope.http.Format;
 import io.pyroscope.javaagent.config.Config;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AsyncProfilerDelegateCommandTest {
+    @Test
+    void jfrStartCommandIncludesFileAndTimeout() {
+        Config config = new Config.Builder()
+            .setFormat(Format.JFR)
+            .setUploadInterval(Duration.ofSeconds(10))
+            .build();
+        File jfrFile = new File("recording.jfr");
+
+        String command = AsyncProfilerDelegate.createStartCommand(config, Format.JFR, jfrFile);
+
+        assertTrue(command.contains("file=" + jfrFile));
+        assertTrue(command.contains("timeout=11"));
+    }
+
     @Test
     void otlpStartCommandIncludesConfiguredOptionsWithoutJfrFile() {
         Config config = new Config.Builder()


### PR DESCRIPTION
## Description

Adds test coverage for the async-profiler JFR start command.

The test verifies that JFR recordings include both the configured recording file and the upload-interval-derived timeout.

## Testing

```text
./gradlew.bat :agent:test \
  --tests io.pyroscope.javaagent.AsyncProfilerDelegateCommandTest
```

Fixes #356.