### PR TITLE
fix(ci): reduce Maven Central rate limiting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           java-version: '21'
           distribution: 'zulu'
+          cache: 'gradle'
+          cache-dependency-path: |
+            **/*.gradle*
+            **/gradle-wrapper.properties
+            .github/workflows/build.yml
       - name: Upgrade Gradle wrapper for newer Java versions
         if: ${{ !contains(fromJSON('["11", "17", "21"]'), matrix.java) }}
         run: ./gradlew wrapper --gradle-version=9.0
@@ -35,4 +40,5 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
+          cache: 'gradle'
       - run: ./gradlew shadowJar

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-x64
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         test: ${{ fromJSON(needs.discover.outputs.tests) }}
         os: [alpine-3.22, alpine-3.23, ubuntu-22.04, ubuntu-24.04]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           java-version: '21'
           distribution: 'zulu'
+          cache: 'gradle'
+          cache-dependency-path: |
+            **/*.gradle*
+            **/gradle-wrapper.properties
+            .github/workflows/test.yml
       - name: Upgrade Gradle wrapper for newer Java versions
         if: ${{ !contains(fromJSON('["11", "17", "21"]'), matrix.java) }}
         run: ./gradlew wrapper --gradle-version=9.0
@@ -35,6 +40,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
+          cache: 'gradle'
       - run: ./gradlew test --stacktrace
   javadoc:
     runs-on: ubuntu-x64
@@ -47,4 +53,5 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
+          cache: 'gradle'
       - run: ./gradlew javaDoc --info


### PR DESCRIPTION
## Summary

- enable Gradle dependency caching in build, test, and Javadoc jobs
- cache dependencies before upgrading the Gradle wrapper for newer Java versions
- limit the integration-test matrix to four concurrent jobs

## Context

The current CI matrix starts many Gradle builds concurrently. Recent runs failed while resolving build dependencies because Maven Central returned HTTP 429 responses. Caching dependencies and limiting integration-test concurrency reduces repeated downloads and request bursts.

Fixes #360 