### PR TITLE
chore(deps): upgrade protobuf-java to 4.35.0

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation('com.squareup.okhttp3:okhttp:4.12.0')
     implementation("com.squareup.moshi:moshi:1.15.2")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.3.0")
-    api 'com.google.protobuf:protobuf-java:4.33.5'
+    api 'com.google.protobuf:protobuf-java:4.35.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.14.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'


### PR DESCRIPTION
Bumps the vendored protobuf runtime from `4.33.5` to `4.35.0`, the latest release on Maven Central (`4.34.2` is a patch on the older 4.34 line).

Related to #361.

### Why 4.35.0 is safe here

- **Java 8 target preserved** — the 4.35.0 jar is still compiled to class file major version 52 and declares `osgi.ee=JavaSE 1.8`, matching the agent's `sourceCompatibility/targetCompatibility = 1.8`.
- **No new transitive dependencies** — `protobuf-java` 4.35.0 has an empty `<dependencies>` block, so the shaded `pyroscope.jar` gains nothing else.
- **Checked-in gencode stays valid** — `agent/src/main/java/io/pyroscope/labels/pb/JfrLabels.java` is generated by protoc 4.26.1 and `RuntimeVersion` only rejects gencode from a different major version or newer than the runtime; 4.26.1 gencode on a 4.35.0 runtime satisfies both.

### Relation to #361

This does **not** silence the JDK 25 warning in #361: `UnsafeUtil$MemoryAccessor` in 4.35.0 still calls `sun.misc.Unsafe::arrayBaseOffset` when the JDK allows it (the default `--sun-misc-unsafe-memory-access=warn` on JDK 25).

What 4.35.0 does add is a graceful fallback: if `sun.misc.Unsafe` is present but configured to throw (`=deny`, and presumably the future default), protobuf now catches that and continues with a non-Unsafe memory accessor at slightly reduced performance instead of failing, and logs that "a later Protobuf version release will stop using sun.misc.Unsafe entirely". So this upgrade removes the "agent breaks completely" outcome described in the issue, and the warning itself will go away with a future protobuf release.

### Testing

I could not build locally (no JDK in my environment) — relying on CI for `./gradlew test` and the Java 8/11/17/21 build matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)