### PR TITLE
test(itest): cover profiling labels end to end

### DIFF
--- a/alpine-test.Dockerfile
+++ b/alpine-test.Dockerfile
@@ -33,7 +33,9 @@ WORKDIR /app
 ADD demo demo
 COPY --from=builder /app/agent/build/libs/pyroscope.jar /app/agent/build/libs/pyroscope.jar
 
-RUN javac demo/src/main/java/Fib.java
+RUN javac -cp /app/agent/build/libs/pyroscope.jar \
+    demo/src/main/java/Fib.java \
+    demo/src/main/java/LabelsApp.java
 
 ENV PYROSCOPE_LOG_LEVEL=debug
 ENV PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040

--- a/demo/src/main/java/LabelsApp.java
+++ b/demo/src/main/java/LabelsApp.java
@@ -1,0 +1,115 @@
+import io.pyroscope.javaagent.PyroscopeAgent;
+import io.pyroscope.javaagent.config.Config;
+import io.pyroscope.labels.v2.ConstantContext;
+import io.pyroscope.labels.v2.LabelsSet;
+import io.pyroscope.labels.v2.Pyroscope;
+
+import java.util.Collections;
+
+/**
+ * Labelled workload for the integration test in itest/labels_test.go.
+ *
+ * <p>Unlike {@link Fib}, every busy thread here runs inside a labelled context, so the profiles this
+ * app uploads exercise the whole labels pipeline end to end: the encoded LabelsSnapshot in the
+ * multipart {@code labels} part, and the static labels folded into the ingest URL.
+ *
+ * <p>Each workload has its own recursive method so that the collapsed flamegraph of one label value
+ * is distinguishable from the others. The test asserts both that each value selects its own stacks
+ * and that it does not select anybody else's.
+ */
+public class LabelsApp {
+
+    private static final long FIB_N = 25L;
+    private static final long IDLE_MILLIS = 2L;
+
+    public static void main(String[] args) {
+        // Seed the constant string table before the first dump(). LabelsWrapper.dump() pre-populates
+        // its string table from the registered constants and derives the ids of the dynamic label
+        // strings from its size, so a non-empty constant table is what makes the per-workload
+        // assertions in the test sensitive to string id collisions between the two.
+        Pyroscope.LabelsWrapper.registerConstant("alpha_const");
+        Pyroscope.LabelsWrapper.registerConstant("beta_const");
+
+        // Must happen before the agent starts: PyroscopeExporter folds the static labels into the
+        // ingest URL once, in its constructor. The container therefore runs with
+        // PYROSCOPE_AGENT_ENABLED=false, so premain injects the bootstrap api but stops short of
+        // building the exporter, and this app starts the agent itself below.
+        Pyroscope.setStaticLabels(Collections.singletonMap("static_label", "static_value"));
+
+        PyroscopeAgent.start(new Config.Builder(Config.build())
+            .setAgentEnabled(true)
+            .build());
+
+        // Everything below has to run after the agent started: ScopedContext silently falls back to
+        // context id 0 - dropping the labels - while ScopedContext.ENABLED is false.
+        final Runnable alpha = () -> {
+            while (true) {
+                fibAlpha(FIB_N);
+                idle();
+            }
+        };
+        final Runnable beta = () -> {
+            while (true) {
+                fibBeta(FIB_N);
+                idle();
+            }
+        };
+
+        // Scoped contexts: labels are dumped from ScopedContext.CONTEXTS.
+        spawn("labels-alpha", () -> Pyroscope.LabelsWrapper.run(new LabelsSet("workload", "alpha"), alpha));
+        spawn("labels-beta", () -> Pyroscope.LabelsWrapper.run(new LabelsSet("workload", "beta"), beta));
+
+        // Constant context: labels are dumped from ScopedContext.CONSTANT_CONTEXTS instead, and the
+        // context id is never released. activate() has to run on the profiled thread, the
+        // async-profiler context id is thread local.
+        final ConstantContext gamma = ConstantContext.of(new LabelsSet("workload", "gamma"));
+        spawn("labels-gamma", () -> {
+            gamma.activate();
+            while (true) {
+                fibGamma(FIB_N);
+                idle();
+            }
+        });
+    }
+
+    private static void spawn(String name, Runnable body) {
+        // Non daemon on purpose: main() returns immediately and these threads keep the JVM alive.
+        new Thread(body, name).start();
+    }
+
+    /**
+     * Leaves some cpu for the other workloads and for the pyroscope container, which shares the two
+     * cores of a CI runner with this app.
+     */
+    private static void idle() {
+        try {
+            Thread.sleep(IDLE_MILLIS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    // Three copies on purpose: the test tells the workloads apart by their frame names.
+
+    private static long fibAlpha(long n) {
+        if (n < 2L) {
+            return n;
+        }
+        return fibAlpha(n - 1) + fibAlpha(n - 2);
+    }
+
+    private static long fibBeta(long n) {
+        if (n < 2L) {
+            return n;
+        }
+        return fibBeta(n - 1) + fibBeta(n - 2);
+    }
+
+    private static long fibGamma(long n) {
+        if (n < 2L) {
+            return n;
+        }
+        return fibGamma(n - 1) + fibGamma(n - 2);
+    }
+}

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -64,13 +64,15 @@ func appImagePrefix(dockerfile string) string {
 	}
 }
 
-func startApp(t *testing.T, net *dockertest.Network, image string, env map[string]string) {
+// startApp starts the app image. An empty cmd keeps the image's own CMD, which runs Fib.
+func startApp(t *testing.T, net *dockertest.Network, image string, env map[string]string, cmd ...string) *dockertest.Container {
 	t.Helper()
 	t.Logf("starting app %s ...", image)
-	dockertest.StartContainer(t, dockertest.ContainerRequest{
+	return dockertest.StartContainer(t, dockertest.ContainerRequest{
 		Image:   image,
 		Network: net.Name,
 		Env:     env,
+		Cmd:     cmd,
 	})
 }
 
@@ -138,32 +140,68 @@ func testTarget(t *testing.T, pyroscopeURL string, serviceName string) {
 	testLabelSelector(t, pyroscopeURL, serviceName, cpuNanosecondsProfileType, labelSelector)
 }
 
+// profileExpectation is what a single label selector's collapsed profile has to look like.
+type profileExpectation struct {
+	labelSelector string
+	// contains is a collapsed stack fragment the profile must have.
+	contains string
+	// absent are fragments the profile must not have. Used to check that a label selects only its
+	// own samples.
+	absent []string
+}
+
 func testLabelSelector(t *testing.T, pyroscopeURL string, targetName string, profileTypeID string, labelSelector string) {
 	t.Helper()
-	var lastCollapsed string
+	testProfiles(t, pyroscopeURL, targetName, profileTypeID, []profileExpectation{
+		{labelSelector: labelSelector, contains: needle},
+	})
+}
+
+// testProfiles waits until every expectation holds. They are all checked on every tick, so the
+// budget is shared rather than paid per selector, and so that "this label selects its own stacks"
+// and "it does not select anybody else's" are decided on the same profiles.
+func testProfiles(t *testing.T, pyroscopeURL string, targetName string, profileTypeID string, expectations []profileExpectation) {
+	t.Helper()
+	lastCollapsed := make([]string, len(expectations))
 	var lastErr error
 	ok := require.Eventually(t, func() bool {
-		lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, profileTypeID, labelSelector)
-		if lastErr != nil {
-			t.Logf("[%s] query %s error: %s", targetName, labelSelector, lastErr)
-			return false
+		satisfied := true
+		for i, e := range expectations {
+			collapsed, err := queryProfile(t, pyroscopeURL, profileTypeID, e.labelSelector)
+			lastCollapsed[i] = collapsed
+			if err != nil {
+				lastErr = err
+				t.Logf("[%s] query %s error: %s", targetName, e.labelSelector, err)
+				satisfied = false
+				continue
+			}
+			if collapsed == "" {
+				t.Logf("[%s] empty profile for %s", targetName, e.labelSelector)
+				satisfied = false
+				continue
+			}
+			if !strings.Contains(collapsed, e.contains) {
+				t.Logf("[%s] %q not found yet for %s", targetName, e.contains, e.labelSelector)
+				satisfied = false
+				continue
+			}
+			for _, a := range e.absent {
+				if strings.Contains(collapsed, a) {
+					t.Logf("[%s] unexpected %q in profile for %s", targetName, a, e.labelSelector)
+					satisfied = false
+				}
+			}
 		}
-		if lastCollapsed == "" {
-			t.Logf("[%s] empty profile for %s", targetName, labelSelector)
-			return false
-		}
-		if !strings.Contains(lastCollapsed, needle) {
-			t.Logf("[%s] needle not found yet for %s", targetName, labelSelector)
-			return false
-		}
-		return true
+		return satisfied
 	}, 3*time.Minute, 5*time.Second)
 
 	if !ok {
 		if lastErr != nil {
-			t.Logf("[%s] last error for %s: %s", targetName, labelSelector, lastErr)
+			t.Logf("[%s] last error: %s", targetName, lastErr)
 		}
-		t.Logf("[%s] last collapsed profile for %s:\n%s", targetName, labelSelector, lastCollapsed)
+		for i, e := range expectations {
+			t.Logf("[%s] last collapsed profile for %s:\n%s", targetName, e.labelSelector, lastCollapsed[i])
+		}
 		t.FailNow()
 	}
 }

--- a/itest/labels_test.go
+++ b/itest/labels_test.go
@@ -1,0 +1,99 @@
+package itest
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"pyroscope-java-itest/dockertest"
+	"pyroscope-java-itest/require"
+)
+
+// Matches demo/src/main/java/LabelsApp.java.
+const (
+	labelsStaticLabel      = "static_label"
+	labelsStaticLabelValue = "static_value"
+	labelsWorkloadLabel    = "workload"
+)
+
+var labelsWorkloads = map[string]string{
+	"alpha": "fibAlpha",
+	"beta":  "fibBeta",
+	"gamma": "fibGamma",
+}
+
+// workloadNeedle is the collapsed stack fragment only the given workload can produce. Two frames so
+// that it also asserts the recursion, and not just a single method name appearing somewhere.
+func workloadNeedle(workload string) string {
+	method := "LabelsApp." + labelsWorkloads[workload]
+	return fmt.Sprintf(";%s;%s;", method, method)
+}
+
+// TestQueryProfileLabels covers the labels pipeline end to end: the encoded LabelsSnapshot uploaded
+// as the multipart "labels" part, and the static labels folded into the ingest URL. LabelsApp runs
+// three busy threads, each under a different "workload" label, so a mix-up between contexts, or
+// between the label strings, shows up as a workload's stacks landing under the wrong label.
+func TestQueryProfileLabels(t *testing.T) {
+	net := dockertest.CreateNetwork(t)
+
+	pyroscopeURL := startPyroscope(t, net)
+	t.Logf("pyroscope URL: %s", pyroscopeURL)
+
+	dockerfile, imageVersion, javaVersion := envDockerfile(), envImageVersion(), envJavaVersion()
+	image := buildAppImage(t, dockerfile, imageVersion, javaVersion)
+	serviceName := serviceNameFromDockerfile(dockerfile, imageVersion, javaVersion) + "-labels"
+
+	startApp(t, net, image, map[string]string{
+		"PYROSCOPE_APPLICATION_NAME": serviceName,
+		// LabelsApp starts the agent itself, so that Pyroscope.setStaticLabels lands before the
+		// exporter is built. See the comment in LabelsApp.main.
+		"PYROSCOPE_AGENT_ENABLED": "false",
+	},
+		"java",
+		"-javaagent:/app/agent/build/libs/pyroscope.jar",
+		"-cp", "/app/agent/build/libs/pyroscope.jar:demo/src/main/java/",
+		"LabelsApp")
+
+	// Static and dynamic labels get separate selectors: a static label reaches the server as a
+	// series label on the ingest URL, a dynamic one as a sample label in the snapshot, and the two
+	// are merged at different stages of the write path. Keeping them apart keeps a failure
+	// attributable to one of them.
+	expectations := []profileExpectation{{
+		labelSelector: fmt.Sprintf(`{service_name="%s",%s="%s"}`,
+			serviceName, labelsStaticLabel, labelsStaticLabelValue),
+		contains: workloadNeedle("alpha"),
+	}}
+	for workload := range labelsWorkloads {
+		expectations = append(expectations, profileExpectation{
+			labelSelector: fmt.Sprintf(`{service_name="%s",%s="%s"}`,
+				serviceName, labelsWorkloadLabel, workload),
+			contains: workloadNeedle(workload),
+			absent:   otherWorkloadNeedles(workload),
+		})
+	}
+	testProfiles(t, pyroscopeURL, serviceName, cpuNanosecondsProfileType, expectations)
+
+	// The checks above would also pass if the server ignored the workload label altogether and
+	// merged everything into one series, so make sure an unknown value selects nothing.
+	requireNoProfile(t, pyroscopeURL, serviceName,
+		fmt.Sprintf(`{service_name="%s",%s="nonexistent"}`, serviceName, labelsWorkloadLabel))
+}
+
+func otherWorkloadNeedles(workload string) []string {
+	var needles []string
+	for other := range labelsWorkloads {
+		if other != workload {
+			needles = append(needles, workloadNeedle(other))
+		}
+	}
+	return needles
+}
+
+func requireNoProfile(t *testing.T, pyroscopeURL string, targetName string, labelSelector string) {
+	t.Helper()
+	require.Never(t, func() bool {
+		collapsed, err := queryProfile(t, pyroscopeURL, cpuNanosecondsProfileType, labelSelector)
+		return err == nil && collapsed != ""
+	}, 20*time.Second, 5*time.Second,
+		"[%s] selector %s should not match any profile", targetName, labelSelector)
+}

--- a/ubuntu-test.Dockerfile
+++ b/ubuntu-test.Dockerfile
@@ -37,7 +37,9 @@ WORKDIR /app
 ADD demo demo
 COPY --from=builder /app/agent/build/libs/pyroscope.jar /app/agent/build/libs/pyroscope.jar
 
-RUN javac demo/src/main/java/Fib.java
+RUN javac -cp /app/agent/build/libs/pyroscope.jar \
+    demo/src/main/java/Fib.java \
+    demo/src/main/java/LabelsApp.java
 
 ENV PYROSCOPE_LOG_LEVEL=debug
 ENV PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040


### PR DESCRIPTION
Follow-up to #363, which noted:

> The `labels` part still is not covered by the Go integration tests — the demo app they run uses no dynamic labels. Worth a follow-up; I did not add it here because there is no Go toolchain in my environment to verify it.

The itests ran `demo/src/main/java/Fib.java`, which sets no labels at all. So nothing verified that the `LabelsSnapshot` the agent encodes is actually parsed by a real Pyroscope into the series a user queries. The JUnit tests in #363 can only prove the new encoder matches the old one; only an integration test proves the server agrees.

This adds `TestQueryProfileLabels`. It is independent of #363 and applies to `main` as-is.

### The workload

`demo/src/main/java/LabelsApp.java` runs three busy threads, each under a distinct `workload` label value and each looping its **own** recursive method, so the workloads are distinguishable in a collapsed flamegraph:

| thread | label | mechanism |
|---|---|---|
| `labels-alpha` | `workload=alpha` | `Pyroscope.LabelsWrapper.run` + `LabelsSet` → `ScopedContext.CONTEXTS` |
| `labels-beta` | `workload=beta` | same |
| `labels-gamma` | `workload=gamma` | `ConstantContext.of(...).activate()` → `ScopedContext.CONSTANT_CONTEXTS` |

Plus `Pyroscope.setStaticLabels` (a different path — folded into the ingest URL's `name=` parameter, not the snapshot) and two `registerConstant` calls so the dump's string table is pre-seeded. That last part is not decoration: `dump()` pre-populates its string table from `CONSTANTS` and derives the dynamic label ids from its size, so a non-empty constant table is what makes the assertions below sensitive to string-id collisions between the two — the class of bug #363 fixed.

### The assertions

All through the existing `SelectMergeStacktraces` client; no new querier endpoints and no new Go dependencies.

1. `{service_name=…, static_label="static_value"}` is non-empty — static labels reached the server.
2. For each of `alpha` / `beta` / `gamma`: `{service_name=…, workload="<v>"}` contains that workload's frames **and neither of the other two's**. This is the assertion that exercises the encoder — it fails if the context id → labels mapping or the string table is scrambled.
3. `{service_name=…, workload="nonexistent"}` never matches anything, so 1 and 2 cannot pass by the selector being ignored.

`testLabelSelector` is refactored into a `testProfiles` that checks every selector on the same tick. That keeps the whole test inside one 3-minute budget instead of paying it per selector, and means "selects its own stacks" and "does not select anybody else's" are decided on the same profiles.

`startApp` gains a variadic `cmd` so the new test can override the image's `CMD`; both existing call sites are untouched. The image itself is shared with `TestQueryProfile` — the only Dockerfile change is putting `pyroscope.jar` on the `javac` classpath and compiling `LabelsApp` alongside `Fib`.

### Verification

I installed a Go toolchain this time, so this is actually run, not reasoned about.

| run | result |
|---|---|
| `TestQueryProfileLabels`, ubuntu 22.04 / Java 17 | PASS 134s |
| `TestQueryProfile` + `TestQueryOtlpProfile` (regression for the `startApp` / `testLabelSelector` refactor) | PASS 8.0s / 8.1s |
| `TestQueryProfileLabels`, Java 8 (oldest `javac`) | PASS 107s |
| `TestQueryProfileLabels`, alpine 3.23 | PASS 92s |
| `TestQueryProfileLabels`, Java 25 (Gradle 9 path) | PASS 132s |

Mutation-tested so it is not passing vacuously: giving `gamma` the label value `alpha` fails with

```
unexpected ";LabelsApp.fibGamma;LabelsApp.fibGamma;" in profile for {service_name="…",workload="alpha"}
```

`go vet` and `gofmt` clean.

### Two things worth a look in review

- **`Pyroscope.setStaticLabels` is a no-op under `-javaagent`.** `PyroscopeExporter` computes the ingest URL's `name=` parameter once in its constructor, and the exporter is built inside `PyroscopeAgent.start()` — which under `-javaagent` runs in `premain`, before `main()`. `demo/src/main/java/App.java:33` has exactly this bug today. To cover the API for real, `LabelsApp` runs with `PYROSCOPE_AGENT_ENABLED=false` and starts the agent itself, the same trick `itest/bootstrap/Dockerfile` already uses. If you would rather the test not depend on restart-after-disabled-premain, `PYROSCOPE_LABELS=static_label=static_value` merges through the identical `nameWithStaticLabels()` path and would let the app run under a plain enabled `-javaagent`.
- **CI cost.** The matrix is derived from `go test -list`, so a new top-level test adds 4 OS × 5 Java = 20 jobs, each doing a full multi-stage Docker build including `./gradlew shadowJar`. That is deliberate here — labels on Java 8 and on musl are worth covering — but if it is too much, the alternatives are folding the labelled container into `TestQueryProfile` (same Pyroscope, same image, zero extra jobs) or self-skipping on non-default combos like `TestBootstrapClassloader` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
