### PR TITLE
fix: upgrade protobuf-java to 4.36.1 to stop using sun.misc.Unsafe

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation('com.squareup.okhttp3:okhttp:4.12.0')
     implementation("com.squareup.moshi:moshi:1.15.2")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.3.0")
-    api 'com.google.protobuf:protobuf-java:4.33.5'
+    api 'com.google.protobuf:protobuf-java:4.36.1'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.14.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'


### PR DESCRIPTION
Fixes #361

## What

Bumps the vendored `com.google.protobuf:protobuf-java` from `4.33.5` to `4.36.1`. That is the whole change.

## Why this fixes it

protobuf [v36.0](https://github.com/protocolbuffers/protobuf/releases/tag/v36.0) stopped routing standard (non-lite) generated code through `UnsafeUtil`. Our `JfrLabels` gencode is full, not lite, so `UnsafeUtil` is now never class-loaded and the JDK 24+ warning never fires.

Note that 4.36.1 still *contains* `sun.misc.Unsafe` references (kept for the Lite path) and the classes are still in the shaded jar — they are just never touched. It also makes `getUnsafe()` probe `arrayBaseOffset` and fall back gracefully if it throws, which fixes the second half of the issue: with 4.33.5 the agent hard-crashes under `--sun-misc-unsafe-memory-access=deny`.

Gencode/runtime compatibility is fine: our checked-in gencode is 4.26.1, same major, older minor, which `RuntimeVersion` accepts. protobuf-java 4.36.1 still targets class file major 52 (Java 8) and has no transitive dependencies.

## Verification

Built `pyroscope.jar` before and after via `ubuntu-test.Dockerfile`, ran the same labels-serializing program under Temurin 25.0.4 with `-javaagent`:

Before (4.33.5):
```
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by io.pyroscope.vendor.com.google.protobuf.UnsafeUtil$MemoryAccessor (file:/w/pyroscope.jar)
WARNING: Please consider reporting this to the maintainers of class io.pyroscope.vendor.com.google.protobuf.UnsafeUtil$MemoryAccessor
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release
dump bytes=39
```

After (4.36.1):
```
dump bytes=39
```

(The unrelated `java.lang.System::load` restricted-method warning from async-profiler is present in both and untouched by this PR.)

Also checked the `--sun-misc-unsafe-memory-access=deny` case with a plain roundtrip over our `JfrLabels` gencode — 4.33.5 dies with `ExceptionInInitializerError` / `UnsupportedOperationException: arrayBaseOffset`, 4.36.1 round-trips fine.

`./gradlew test` passes (run in the Java 11 builder container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)